### PR TITLE
BLISS extension to three-body Hamiltonian

### DIFF
--- a/src/UTILS/bliss.jl
+++ b/src/UTILS/bliss.jl
@@ -1,804 +1,1598 @@
 #routines for finding fluid-body symmetry shifts
-function bliss_sym_params_to_F_OP(ovec, t1, t2, η, N = Int((sqrt(8*length(ovec)+1) - 1)/2), spin_orb=false)
-	#builds S symmetry shift corresponding to S = s0+s1+s2
-	obt = zeros(N, N)
-	idx = 0
-	for i in 1:N
-		for j in 1:i
-			idx += 1
-			obt[i,j] += ovec[idx]
-			obt[j,i] += ovec[idx]
-		end
-	end
 
-	s0 = [-t1*(η^2) - t2*η]
-	s1 = t2*collect(Diagonal(ones(N))) - η*obt
+using Optim
 
-	s2 = zeros(N,N,N,N)
-	for i in 1:N
-		for j in 1:N
-			s2[i,i,j,j] += t1
-			for k in 1:N
-				s2[i,j,k,k] += 0.5*obt[i,j]
-				s2[k,k,i,j] += 0.5*obt[i,j]
-			end
-		end
-	end
+function bliss_sym_params_to_F_OP(ovec, t1, t2, η, N=Int((sqrt(8 * length(ovec) + 1) - 1) / 2), spin_orb=false)
+  #builds S symmetry shift corresponding to S = s0+s1+s2
+  obt = zeros(N, N)
+  idx = 0
+  for i in 1:N
+    for j in 1:i
+      idx += 1
+      obt[i, j] += ovec[idx]
+      obt[j, i] += ovec[idx]
+    end
+  end
 
-	return F_OP((s0, s1, s2), spin_orb)
+  s0 = [-t1 * (η^2) - t2 * η]
+  s1 = t2 * collect(Diagonal(ones(N))) - η * obt
+
+  s2 = zeros(N, N, N, N)
+  for i in 1:N
+    for j in 1:N
+      s2[i, i, j, j] += t1
+      for k in 1:N
+        s2[i, j, k, k] += 0.5 * obt[i, j]
+        s2[k, k, i, j] += 0.5 * obt[i, j]
+      end
+    end
+  end
+
+  return F_OP((s0, s1, s2), spin_orb)
 end
 
 function quadratic_bliss_params_to_F_OP(u1, u2, ovec, η, N)
-	
-	omat = zeros(N,N)
-	idx=1
-	for i=1:N
-		for j=i:N
-			omat[i,j]=ovec[idx]
-			omat[j,i]=ovec[idx]
-			idx+=1
-		end
-	end
-	
-	
-	
-	Sconst = [-η - η^2]
+  if length(ovec) == Int(N * (N + 1) / 2)
+    omat = zeros(N, N)
+    idx = 1
+    for i = 1:N
+      for j = i:N
+        omat[i, j] = ovec[idx]
+        omat[j, i] = ovec[idx]
+        idx += 1
+      end
+    end
 
-	Sobt = zeros(N, N)
-	Tobt = zeros(N, N)
-	for i in 1:N
-		Sobt[i,i] = u1
-		for j in 1:N
-			Tobt[i,j] = -2*η*omat[i,j]
-		end
-	end
 
-	Stbt = zeros(N, N, N, N)
-	Ttbt = zeros(N, N, N, N)
 
-	for i in 1:N
-		for j in 1:N
-			Stbt[i,i,j,j] = u2
-			for k in 1:N
-				
-				Ttbt[i,j,k,k] += omat[i,j]
-				Ttbt[k,k,i,j] += omat[i,j]
-			end
-		end
-	end
+    Sconst = [-u1 * η - u2 * η^2]
 
-	S = F_OP((Sconst, Sobt, Stbt))
-	T = F_OP(([0], Tobt, Ttbt))
-	ST = S+T
-	return ST
+    Sobt = zeros(N, N)
+    Tobt = zeros(N, N)
+    for i in 1:N
+      Sobt[i, i] = u1
+      for j in 1:N
+        Tobt[i, j] = -2 * η * omat[i, j]
+      end
+    end
+
+    Stbt = zeros(N, N, N, N)
+    Ttbt = zeros(N, N, N, N)
+
+    for i in 1:N
+      for j in 1:N
+        Stbt[i, i, j, j] = u2
+        for k in 1:N
+
+          Ttbt[i, j, k, k] += omat[i, j]
+          Ttbt[k, k, i, j] += omat[i, j]
+        end
+      end
+    end
+
+    S = F_OP((Sconst, Sobt, Stbt))
+    T = F_OP(([0], Tobt, Ttbt))
+    ST = S + T
+    return ST
+  else
+    idx = 1
+    O = zeros(2, N, N)
+    for s = 1:2
+      for i = 1:N
+        for j = i:N
+          O[s, i, j] = ovec[idx]
+          O[s, j, i] = ovec[idx]
+          idx += 1
+        end
+      end
+    end
+
+
+    Ne, Ne2 = symmetry_builder(N)
+
+
+    s2_tbt = zeros(4, N, N, N, N)
+    for i = 1:4
+      s2_tbt[i, :, :, :, :] = u2 * Ne2.mbts[3]
+    end
+
+    for sigma = 1:4
+      for i in 1:N
+        for j in 1:N
+          for k in 1:N
+            s2_tbt[sigma, i, j, k, k] += 2 * O[div(sigma - 1, 2)+1, i, j]
+            #s2_tbt[sigma,k,k,i,j] += O[div(sigma-1,2)+1,i,j]
+
+          end
+        end
+      end
+    end
+
+    s1_obt = zeros(2, N, N)
+    for i = 1:2
+      s1_obt[i, :, :] = u1 * Ne.mbts[2] .- 2η * O[i, :, :]
+    end
+
+    S = F_OP(([-u1 * η - u2 * η^2], s1_obt, s2_tbt))
+    return S
+  end
+
 end
 
 
 function bliss_linprog_params_to_F_OP(u1, u2, ovec, η, N)
-	
-	omat = zeros(N,N)
-	idx=1
-	for i=1:N
-		for j=i:N
-			omat[i,j]=ovec[idx]
-			omat[j,i]=ovec[idx]
-			idx+=1
-		end
-	end
-	
-	
-	
-	Sconst = [-η - η^2]
 
-	Sobt = zeros(N, N)
-	Tobt = zeros(N, N)
-	for i in 1:N
-		Sobt[i,i] = u1
-		for j in 1:N
-			Tobt[i,j] = -η*omat[i,j]
-		end
-	end
+  omat = zeros(N, N)
+  idx = 1
+  for i = 1:N
+    for j = i:N
+      omat[i, j] = ovec[idx]
+      omat[j, i] = ovec[idx]
+      idx += 1
+    end
+  end
 
-	Stbt = zeros(N, N, N, N)
-	Ttbt = zeros(N, N, N, N)
 
-	for i in 1:N
-		for j in 1:N
-			Stbt[i,i,j,j] = u2
-			for k in 1:N
-				
-				Ttbt[i,j,k,k] += 0.5*omat[i,j]
-				Ttbt[k,k,i,j] += 0.5*omat[i,j]
-			end
-		end
-	end
 
-	S = F_OP((Sconst, Sobt, Stbt))
-	T = F_OP(([0], Tobt, Ttbt))
-	ST = S+T
-	return ST
+  Sconst = [-η - η^2]
+
+  Sobt = zeros(N, N)
+  Tobt = zeros(N, N)
+  for i in 1:N
+    Sobt[i, i] = u1
+    for j in 1:N
+      Tobt[i, j] = -η * omat[i, j]
+    end
+  end
+
+  Stbt = zeros(N, N, N, N)
+  Ttbt = zeros(N, N, N, N)
+
+  for i in 1:N
+    for j in 1:N
+      Stbt[i, i, j, j] = u2
+      for k in 1:N
+
+        Ttbt[i, j, k, k] += 0.5 * omat[i, j]
+        Ttbt[k, k, i, j] += 0.5 * omat[i, j]
+      end
+    end
+  end
+
+  S = F_OP((Sconst, Sobt, Stbt))
+  T = F_OP(([0], Tobt, Ttbt))
+  ST = S + T
+  return ST
 end
-	
 
-function quadratic_ss(F :: F_OP, η)
-	hij = F.mbts[2]
-	gijkl = F.mbts[3]
 
-	H = sum([hij[i,i] for i in 1:F.N])
-	G = sum([gijkl[i,i,j,j] for i in 1:F.N, j in 1:F.N])
+function quadratic_ss(F::F_OP, η)
+  hij = F.mbts[2]
+  gijkl = F.mbts[3]
 
-	G1 = 0.0
-	for i in 1:F.N
-		for j in 1:i-1
-			G1 += gijkl[i,j,j,i] - gijkl[i,i,j,j]
-		end
-	end
+  H = sum([hij[i, i] for i in 1:F.N])
+  G = sum([gijkl[i, i, j, j] for i in 1:F.N, j in 1:F.N])
 
-	u2 = 4*(G + G1/2)/(5*(F.N^2) - F.N)
-	u1 = (H + 2G - 2*(F.N^2)*u2)/F.N
+  G1 = 0.0
+  for i in 1:F.N
+    for j in 1:i-1
+      G1 += gijkl[i, j, j, i] - gijkl[i, i, j, j]
+    end
+  end
 
-	Sconst = [-η - η^2]
+  u2 = 4 * (G + G1 / 2) / (5 * (F.N^2) - F.N)
+  u1 = (H + 2G - 2 * (F.N^2) * u2) / F.N
 
-	Sobt = zeros(F.N, F.N)
-	for i in 1:F.N
-		Sobt[i,i] = u1
-	end
+  Sconst = [-η - η^2]
 
-	Stbt = zeros(F.N, F.N, F.N, F.N)
-	
-	for i in 1:F.N
-		for j in 1:F.N
-			Stbt[i,i,j,j] = u2
-		end
-	end
+  Sobt = zeros(F.N, F.N)
+  for i in 1:F.N
+    Sobt[i, i] = u1
+  end
 
-	S = F_OP((Sconst, Sobt, Stbt))
+  Stbt = zeros(F.N, F.N, F.N, F.N)
 
-	return F - S
+  for i in 1:F.N
+    for j in 1:F.N
+      Stbt[i, i, j, j] = u2
+    end
+  end
+
+  S = F_OP((Sconst, Sobt, Stbt))
+
+  return F - S
 end
 
 
 
 function quadratic_bliss(F, η)
-	hij = F.mbts[2]
-	gijkl = F.mbts[3]
+  hij = F.mbts[2]
+  gijkl = F.mbts[3]
 
-	H = sum([hij[i,i] for i in 1:F.N])
-	G = sum([gijkl[i,i,j,j] for i in 1:F.N, j in 1:F.N])
+  H = sum([hij[i, i] for i in 1:F.N])
+  G = sum([gijkl[i, i, j, j] for i in 1:F.N, j in 1:F.N])
 
-	G1 = 0.0
-	
+  G1 = 0.0
 
-	for i in 1:F.N
-		for j in 1:i-1
-			G1 += gijkl[i,j,j,i] - gijkl[i,i,j,j]
-		end
-	end
 
-	Gnm = zeros(F.N, F.N)
-	
-	
-	Gtilde_nm = zeros(F.N, F.N)
-	Htilde_nm = zeros(F.N, F.N)
+  for i in 1:F.N
+    for j in 1:i-1
+      G1 += gijkl[i, j, j, i] - gijkl[i, i, j, j]
+    end
+  end
 
-	for n in 1:F.N
-		for m in 1:F.N
-			Gnm[n,m] = sum([gijkl[n,m,k,k] for k in 1:F.N])
-			
-			for k in 1:F.N
-				if k != n && k != m
-					Gtilde_nm[n,m] += gijkl[n,k,k,m] - gijkl[n,m,k,k]
-				end
-			end
-			Htilde_nm[n,m] = 4*(η-F.N)*(hij[n,m] + 2*Gnm[n,m]) - 2*Gnm[n,m] + 2*Gtilde_nm[n,m]
-		end
-	end
+  Gnm = zeros(F.N, F.N)
 
-	omat = zeros(F.N, F.N)
-	for i in 1:F.N
-		for j in i+1:F.N
-			omat[i,j] = omat[j,i] = -Htilde_nm[i,j]/(8(η-F.N)^2+2F.N+2(F.N-2))
-		end
-	end
 
-	α = 8*(η-F.N)^2+4(F.N-1)
-	β = 24F.N-16η+4
-	γ = 8F.N-4η
-	δ = 16F.N^2-8η*F.N+4F.N-2
+  Gtilde_nm = zeros(F.N, F.N)
+  Htilde_nm = zeros(F.N, F.N)
 
-	Htilde_n = zeros(F.N)
-	for n in 1:F.N
-		Htilde_n[n] = 4*(η-F.N)*(hij[n,n] + 2*Gnm[n,n]) + 2*Gtilde_nm[n,n] - 2*Gnm[n,n]
-	end
+  for n in 1:F.N
+    for m in 1:F.N
+      Gnm[n, m] = sum([gijkl[n, m, k, k] for k in 1:F.N])
 
-	μ1 = -2/F.N
-	μ2 = (2G1-G)/(F.N*(1-2F.N))
-	λ1 = (H+2*G)/F.N
-	λ2 = -2*F.N
-	λ3 = 2*(η-2*F.N)/F.N
+      for k in 1:F.N
+        if k != n && k != m
+          Gtilde_nm[n, m] += gijkl[n, k, k, m] - gijkl[n, m, k, k]
+        end
+      end
+      Htilde_nm[n, m] = 4 * (η - F.N) * (hij[n, m] + 2 * Gnm[n, m]) - 2 * Gnm[n, m] + 2 * Gtilde_nm[n, m]
+    end
+  end
 
-	ee = β+γ*λ1*μ1+γ*λ3+δ*μ1
-	Htt_n = zeros(F.N)
-	for n in 1:F.N
-		Htt_n[n] = Htilde_n[n]-4H-8G + γ*(λ1+λ2*μ2) + δ*μ2
-	end
+  omat = zeros(F.N, F.N)
+  for i in 1:F.N
+    for j in i+1:F.N
+      omat[i, j] = omat[j, i] = -Htilde_nm[i, j] / (8(η - F.N)^2 + 2F.N + 2(F.N - 2))
+    end
+  end
 
-	Htt = sum(Htt_n)
-	Osum = -Htt/(α+ee*F.N)
+  α = 8 * (η - F.N)^2 + 4(F.N - 1)
+  β = 24F.N - 16η + 4
+  γ = 8F.N - 4η
+  δ = 16F.N^2 - 8η * F.N + 4F.N - 2
 
-	for n in 1:F.N
-		omat[n,n] = -(Htt_n[n] + Osum*ee)/α
-	end
+  Htilde_n = zeros(F.N)
+  for n in 1:F.N
+    Htilde_n[n] = 4 * (η - F.N) * (hij[n, n] + 2 * Gnm[n, n]) + 2 * Gtilde_nm[n, n] - 2 * Gnm[n, n]
+  end
 
-	u2 = μ1*Osum + μ2
-	u1 = λ1 + λ2*u2 + λ3*Osum
-	
+  μ1 = -2 / F.N
+  μ2 = (2G1 - G) / (F.N * (1 - 2F.N))
+  λ1 = (H + 2 * G) / F.N
+  λ2 = -2 * F.N
+  λ3 = 2 * (η - 2 * F.N) / F.N
 
-	Sconst = [-η - η^2]
+  ee = β + γ * λ1 * μ1 + γ * λ3 + δ * μ1
+  Htt_n = zeros(F.N)
+  for n in 1:F.N
+    Htt_n[n] = Htilde_n[n] - 4H - 8G + γ * (λ1 + λ2 * μ2) + δ * μ2
+  end
 
-	Sobt = zeros(F.N, F.N)
-	Tobt = zeros(F.N, F.N)
-	for i in 1:F.N
-		Sobt[i,i] = u1
-		for j in 1:F.N
-			Tobt[i,j] = -2*η*omat[i,j]
-		end
-	end
+  Htt = sum(Htt_n)
+  Osum = -Htt / (α + ee * F.N)
 
-	Stbt = zeros(F.N, F.N, F.N, F.N)
-	Ttbt = zeros(F.N, F.N, F.N, F.N)
+  for n in 1:F.N
+    omat[n, n] = -(Htt_n[n] + Osum * ee) / α
+  end
 
-	for i in 1:F.N
-		for j in 1:F.N
-			Stbt[i,i,j,j] = u2
-			for k in 1:F.N
-				Ttbt[i,j,k,k] += omat[i,j]
-				Ttbt[k,k,i,j] += omat[i,j]
-			end
-		end
-	end
-	
-	S = F_OP((Sconst, Sobt, Stbt))
-	T = F_OP(([0], Tobt, Ttbt))
+  u2 = μ1 * Osum + μ2
+  u1 = λ1 + λ2 * u2 + λ3 * Osum
 
-	FT = F - S - T
-	@show PAULI_L2(FT)
-	@show PAULI_L1(FT)
-	
 
-	return FT
+  Sconst = [-η - η^2]
+
+  Sobt = zeros(F.N, F.N)
+  Tobt = zeros(F.N, F.N)
+  for i in 1:F.N
+    Sobt[i, i] = u1
+    for j in 1:F.N
+      Tobt[i, j] = -2 * η * omat[i, j]
+    end
+  end
+
+  Stbt = zeros(F.N, F.N, F.N, F.N)
+  Ttbt = zeros(F.N, F.N, F.N, F.N)
+
+  for i in 1:F.N
+    for j in 1:F.N
+      Stbt[i, i, j, j] = u2
+      for k in 1:F.N
+        Ttbt[i, j, k, k] += omat[i, j]
+        Ttbt[k, k, i, j] += omat[i, j]
+      end
+    end
+  end
+
+  S = F_OP((Sconst, Sobt, Stbt))
+  T = F_OP(([0], Tobt, Ttbt))
+
+  FT = F - S - T
+  @show PAULI_L2(FT)
+  @show PAULI_L1(FT)
+
+
+  return FT
 end
 
-function bliss_optimizer(F :: F_OP, η; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		if haskey(fid, "BLISS")
-			BLISS_group = fid["BLISS"]
-			if haskey(BLISS_group, "ovec")
-				println("Loading results for BLISS optimization from $SAVENAME")
-				ovec = read(BLISS_group,"ovec")
-				t1 = read(BLISS_group,"t1")
-				t2 = read(BLISS_group,"t2")
-				close(fid)
+function bliss_optimizer(F::F_OP, η; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    if haskey(fid, "BLISS")
+      BLISS_group = fid["BLISS"]
+      if haskey(BLISS_group, "ovec")
+        println("Loading results for BLISS optimization from $SAVENAME")
+        ovec = read(BLISS_group, "ovec")
+        t1 = read(BLISS_group, "t1")
+        t2 = read(BLISS_group, "t2")
+        close(fid)
 
-				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
-				close(fid)
-				return F-S
-			end
-		end
-		close(fid)
-	end
+        S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
+        close(fid)
+        return F - S
+      end
+    end
+    close(fid)
+  end
 
-	L = Int(F.N*(F.N+1)/2)
-	x0 = zeros(L + 2)
+  L = Int(F.N * (F.N + 1) / 2)
+  x0 = zeros(L + 2)
 
-	function cost(x)
-		return PAULI_L1(F - bliss_sym_params_to_F_OP(x[3:end], x[1], x[2], η, F.N, F.spin_orb))
-	end
+  function cost(x)
+    return PAULI_L1(F - bliss_sym_params_to_F_OP(x[3:end], x[1], x[2], η, F.N, F.spin_orb))
+  end
 
-	if verbose
-		println("Starting 1-norm cost:")
-		@show cost(x0)
-		@time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol = 1e-3))
-		println("Final 1-norm cost:")
-		@show sol.minimum
-	else
-		sol = optimize(cost, x0, BFGS())
-	end
+  if verbose
+    println("Starting 1-norm cost:")
+    @show cost(x0)
+    @time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol=1e-3))
+    println("Final 1-norm cost:")
+    @show sol.minimum
+  else
+    sol = optimize(cost, x0, BFGS())
+  end
 
-	xsol = sol.minimizer
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		create_group(fid, "BLISS")
-		BLISS_group = fid["BLISS"]
-		println("Saving results of BLISS optimization to $SAVENAME")
-		BLISS_group["ovec"] = xsol[3:end]
-		BLISS_group["t1"] = xsol[1]
-		BLISS_group["t2"] = xsol[2]
-		close(fid)
-	end
-	S = bliss_sym_params_to_F_OP(xsol[3:end], xsol[1], xsol[2], η, F.N, F.spin_orb)
+  xsol = sol.minimizer
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    create_group(fid, "BLISS")
+    BLISS_group = fid["BLISS"]
+    println("Saving results of BLISS optimization to $SAVENAME")
+    BLISS_group["ovec"] = xsol[3:end]
+    BLISS_group["t1"] = xsol[1]
+    BLISS_group["t2"] = xsol[2]
+    close(fid)
+  end
+  S = bliss_sym_params_to_F_OP(xsol[3:end], xsol[1], xsol[2], η, F.N, F.spin_orb)
 
-	return F - S
+  return F - S
 end
 
-function quadratic_bliss_optimizer(F :: F_OP, η; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
-	#=if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		if haskey(fid, "BLISS")
-			BLISS_group = fid["BLISS"]
-			if haskey(BLISS_group, "ovec")
-				println("Loading results for BLISS optimization from $SAVENAME")
-				ovec = read(BLISS_group,"ovec")
-				t1 = read(BLISS_group,"t1")
-				t2 = read(BLISS_group,"t2")
-				close(fid)
-				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
-				close(fid)
-				return F-S
-			end
-		end
-		close(fid)
-	end=#
-	L = Int(F.N*(F.N+1)/2)
-	x0 = zeros(L + 2)
-	
-	
-	function cost(x)
-		#@show quadratic_bliss_gradient(x, F, η, F.N)
-		return PAULI_L1(F - quadratic_bliss_params_to_F_OP(x[1], x[2], x[3:end], η, F.N))
-	end
-	
-	#=function grad!(storage,x)
-		storage.=quadratic_bliss_gradient(x, F, η, F.N)
-	end=#
-	
-	if verbose
-		println("Starting 1-norm cost:")
-		@show cost(x0)
-		@time sol = optimize(cost,  x0, BFGS(), Optim.Options(show_trace=false, extended_trace=true, show_every=1, f_tol = 1e-3))
-		println("Final 1-norm cost:")
-		@show sol.minimum
-	else
-		sol = optimize(cost, x0, BFGS())
-	end
-	
-	@show xsol = sol.minimizer
-	#=if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		create_group(fid, "BLISS")
-		BLISS_group = fid["BLISS"]
-		println("Saving results of BLISS optimization to $SAVENAME")
-		BLISS_group["ovec"] = xsol[3:end]
-		BLISS_group["t1"] = xsol[1]
-		BLISS_group["t2"] = xsol[2]
-		close(fid)
-	end=#
-	ST = quadratic_bliss_params_to_F_OP(xsol[1], xsol[2], xsol[3:end], η, F.N)
+function quadratic_bliss_optimizer(F::F_OP, η; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
+  #=if SAVELOAD
+  		fid = h5open(SAVENAME, "cw")
+  		if haskey(fid, "BLISS")
+  			BLISS_group = fid["BLISS"]
+  			if haskey(BLISS_group, "ovec")
+  				println("Loading results for BLISS optimization from $SAVENAME")
+  				ovec = read(BLISS_group,"ovec")
+  				t1 = read(BLISS_group,"t1")
+  				t2 = read(BLISS_group,"t2")
+  				close(fid)
+  				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
+  				close(fid)
+  				return F-S
+  			end
+  		end
+  		close(fid)
+  	end=#
+  if size(F.mbts[2], 1) == size(F.mbts[3], 1)
+    L = Int(F.N * (F.N + 1) / 2)
+  else
+    L = F.N * (F.N + 1)
+  end
+  x0 = zeros(L + 2)
 
-	return F - ST
+
+  function cost(x)
+    #@show quadratic_bliss_gradient(x, F, η, F.N)
+    return PAULI_L1(F - quadratic_bliss_params_to_F_OP(x[1], x[2], x[3:end], η, F.N))
+  end
+
+  #=function grad!(storage,x)
+  		storage.=quadratic_bliss_gradient(x, F, η, F.N)
+  	end=#
+
+  if verbose
+    println("Starting 1-norm cost:")
+    @show cost(x0)
+    @time sol = Optim.optimize(cost, x0, BFGS(), Optim.Options(show_trace=false, extended_trace=true, show_every=1, f_tol=1e-3))
+    println("Final 1-norm cost:")
+    @show sol.minimum
+  else
+    sol = optimize(cost, x0, BFGS())
+  end
+
+  @show xsol = sol.minimizer
+  #=if SAVELOAD
+  		fid = h5open(SAVENAME, "cw")
+  		create_group(fid, "BLISS")
+  		BLISS_group = fid["BLISS"]
+  		println("Saving results of BLISS optimization to $SAVENAME")
+  		BLISS_group["ovec"] = xsol[3:end]
+  		BLISS_group["t1"] = xsol[1]
+  		BLISS_group["t2"] = xsol[2]
+  		close(fid)
+  	end=#
+  ST = quadratic_bliss_params_to_F_OP(xsol[1], xsol[2], xsol[3:end], η, F.N)
+
+  return F - ST
 end
 
 function Sz_builder(n_qubit)
-	Sz = zeros(n_qubit, n_qubit)
-	for i in 1:n_qubit
-		if i%2 == 1
-			Sz[i,i] = 1
-		else
-			Sz[i,i] = -1
-		end
-	end
+  Sz = zeros(n_qubit, n_qubit)
+  for i in 1:n_qubit
+    if i % 2 == 1
+      Sz[i, i] = 1
+    else
+      Sz[i, i] = -1
+    end
+  end
 
-	return Sz
+  return Sz
 end
 
 function S2_builder(n_qubit)
-	S2_tbt = zeros(n_qubit,n_qubit,n_qubit,n_qubit)
-	n_orbs = Int(n_qubit/2)
-	for i in 1:n_orbs
-		ka = 2i-1
-		kb = 2i
-		S2_tbt[ka,ka,ka,ka] += 1
-		S2_tbt[kb,kb,kb,kb] += 1
-		S2_tbt[ka,ka,kb,kb] += -1
-		S2_tbt[kb,kb,ka,ka] += -1
-		S2_tbt[ka,kb,kb,ka] += 2
-		S2_tbt[kb,ka,ka,kb] += 2
-	end
+  S2_tbt = zeros(n_qubit, n_qubit, n_qubit, n_qubit)
+  n_orbs = Int(n_qubit / 2)
+  for i in 1:n_orbs
+    ka = 2i - 1
+    kb = 2i
+    S2_tbt[ka, ka, ka, ka] += 1
+    S2_tbt[kb, kb, kb, kb] += 1
+    S2_tbt[ka, ka, kb, kb] += -1
+    S2_tbt[kb, kb, ka, ka] += -1
+    S2_tbt[ka, kb, kb, ka] += 2
+    S2_tbt[kb, ka, ka, kb] += 2
+  end
 
-	for i in 1:n_orbs
-		for j in 1:n_orbs
-			if i != j
-				ka = 2i-1
-				kb = 2i
-				la = 2j-1
-				lb = 2j
-				S2_tbt[ka,kb,lb,la] += 1
-				S2_tbt[lb,la,ka,kb] += 1
-				S2_tbt[kb,ka,la,lb] += 1
-				S2_tbt[la,lb,kb,ka] += 1
-				S2_tbt[ka,ka,la,la] += 0.5
-				S2_tbt[la,la,ka,ka] += 0.5
-				S2_tbt[kb,kb,lb,lb] += 0.5
-				S2_tbt[lb,lb,kb,kb] += 0.5
-				S2_tbt[ka,ka,lb,lb] += -0.5
-				S2_tbt[lb,lb,ka,ka] += -0.5
-				S2_tbt[kb,kb,la,la] += -0.5
-				S2_tbt[la,la,kb,kb] += -0.5
-			end
-		end
-	end
-
-	S2_tbt /= 4
-
-	return S2_tbt
-end
-
-function hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, N = Int((sqrt(8*length(ovec)+1) - 1)/2), Sz = Sz_builder(N), S2=S2_builder(N))
-	#builds S symmetry shift corresponding to S = s0+s1+s2
-	#includes Sz and Sˆ2 contributions, considers spin-orb=true
-	O_obt = zeros(N, N)
-	idx = 0
-	for i in 1:N
-		for j in 1:i
-			idx += 1
-			O_obt[i,j] += ovec[idx]
-			O_obt[j,i] += ovec[idx]
-		end
-	end
-
-	P_obt = zeros(N, N)
-	idx = 0
-	for i in 1:N
-		for j in 1:i
-			idx += 1
-			P_obt[i,j] += pvec[idx]
-			P_obt[j,i] += pvec[idx]
-		end
-	end
-
-	s0 = [-tvec[1]*(η^2) - tvec[2]*η - tvec[3]*sz - tvec[4]*(sz^2) - tvec[5]*s2]
-	
-	s1 = tvec[2]*collect(Diagonal(ones(N))) - η*O_obt - sz*P_obt - tvec[3]*Sz
-
-	s2 = zeros(N,N,N,N)
-	for i in 1:N
-		for j in 1:N
-			s2[i,i,j,j] += tvec[1]
-			for k in 1:N
-				s2[i,j,k,k] += 0.5*O_obt[i,j]
-				s2[k,k,i,j] += 0.5*O_obt[i,j]
-				for l in 1:N
-					s2[i,j,k,l] += tvec[4] * Sz[i,j] * Sz[k,l]
-					s2[i,j,k,l] += tvec[5] * S2[i,j,k,l]
-					s2[i,j,k,l] += P_obt[i,j] * Sz[k,l]
-				end
-			end
-		end
-	end
-
-	return F_OP((s0, s1, s2), true)
-end
-
-function hubbard_bliss_optimizer(F :: F_OP, η, sz, s2; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		if haskey(fid, "BLISS")
-			BLISS_group = fid["BLISS"]
-			if haskey(BLISS_group, "ovec")
-				println("Loading results for BLISS optimization from $SAVENAME")
-				ovec = read(BLISS_group,"ovec")
-				tvec = read(BLISS_group,"tvec")
-				pvec = read(BLISS_group,"pvec")
-				close(fid)
-				S = hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, F.N)
-				close(fid)
-				return F-S
-			end
-		end
-		close(fid)
-	end
-
-	L = Int(F.N*(F.N+1)/2)
-	x0 = zeros(2L + 5)
-
-	if F.spin_orb == true
-		n_qubits = F.N
-	else
-		n_qubits = 2*F.N
-	end
-	Sz = Sz_builder(n_qubits)
-	S2 = S2_builder(n_qubits)
-
-
-	function cost(x)
-		return PAULI_L1(F - hubbard_bliss_sym_params_to_F_OP(x[1:L], x[L+1:2L], x[2L+1:end], η, sz, s2, F.N))
-	end
-
-	if verbose
-		println("Starting 1-norm cost:")
-		@show cost(x0)
-		@time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol = 1e-3))
-		println("Final 1-norm cost:")
-		@show sol.minimum
-	else
-		sol = optimize(cost, x0, BFGS())
-	end
-
-	xsol = sol.minimizer
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		create_group(fid, "BLISS")
-		BLISS_group = fid["BLISS"]
-		println("Saving results of BLISS optimization to $SAVENAME")
-		BLISS_group["ovec"] = xsol[1:L]
-		BLISS_group["pvec"] = xsol[L+1:2L]
-		BLISS_group["tvec"] = xsol[2L+1:end]
-		close(fid)
-	end
-	S = hubbard_bliss_sym_params_to_F_OP(xsol[1:L], xsol[L+1:2L], xsol[2L+1:end], η, sz, s2, F.N)
-
-	return F - S
-end
-
-function bliss_linprog(F :: F_OP, η; model="highs", verbose=false)
-	if F.spin_orb
-		error("BLISS not defined for spin-orb=true!")
-	end
-
-    if model == "highs"
-        L1_OPT = Model(HiGHS.Optimizer)
-    elseif model == "ipopt"
-        L1_OPT = Model(Ipopt.Optimizer)
-    else
-        error("Not defined for model = $model")
+  for i in 1:n_orbs
+    for j in 1:n_orbs
+      if i != j
+        ka = 2i - 1
+        kb = 2i
+        la = 2j - 1
+        lb = 2j
+        S2_tbt[ka, kb, lb, la] += 1
+        S2_tbt[lb, la, ka, kb] += 1
+        S2_tbt[kb, ka, la, lb] += 1
+        S2_tbt[la, lb, kb, ka] += 1
+        S2_tbt[ka, ka, la, la] += 0.5
+        S2_tbt[la, la, ka, ka] += 0.5
+        S2_tbt[kb, kb, lb, lb] += 0.5
+        S2_tbt[lb, lb, kb, kb] += 0.5
+        S2_tbt[ka, ka, lb, lb] += -0.5
+        S2_tbt[lb, lb, ka, ka] += -0.5
+        S2_tbt[kb, kb, la, la] += -0.5
+        S2_tbt[la, la, kb, kb] += -0.5
+      end
     end
-    
-    
-    if verbose == false
-        set_silent(L1_OPT)
+  end
+
+  S2_tbt /= 4
+
+  return S2_tbt
+end
+
+function hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, N=Int((sqrt(8 * length(ovec) + 1) - 1) / 2), Sz=Sz_builder(N), S2=S2_builder(N))
+  #builds S symmetry shift corresponding to S = s0+s1+s2
+  #includes Sz and Sˆ2 contributions, considers spin-orb=true
+  O_obt = zeros(N, N)
+  idx = 0
+  for i in 1:N
+    for j in 1:i
+      idx += 1
+      O_obt[i, j] += ovec[idx]
+      O_obt[j, i] += ovec[idx]
+    end
+  end
+
+  P_obt = zeros(N, N)
+  idx = 0
+  for i in 1:N
+    for j in 1:i
+      idx += 1
+      P_obt[i, j] += pvec[idx]
+      P_obt[j, i] += pvec[idx]
+    end
+  end
+
+  s0 = [-tvec[1] * (η^2) - tvec[2] * η - tvec[3] * sz - tvec[4] * (sz^2) - tvec[5] * s2]
+
+  s1 = tvec[2] * collect(Diagonal(ones(N))) - η * O_obt - sz * P_obt - tvec[3] * Sz
+
+  s2 = zeros(N, N, N, N)
+  for i in 1:N
+    for j in 1:N
+      s2[i, i, j, j] += tvec[1]
+      for k in 1:N
+        s2[i, j, k, k] += 0.5 * O_obt[i, j]
+        s2[k, k, i, j] += 0.5 * O_obt[i, j]
+        for l in 1:N
+          s2[i, j, k, l] += tvec[4] * Sz[i, j] * Sz[k, l]
+          s2[i, j, k, l] += tvec[5] * S2[i, j, k, l]
+          s2[i, j, k, l] += P_obt[i, j] * Sz[k, l]
+        end
+      end
+    end
+  end
+
+  return F_OP((s0, s1, s2), true)
+end
+
+function hubbard_bliss_optimizer(F::F_OP, η, sz, s2; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    if haskey(fid, "BLISS")
+      BLISS_group = fid["BLISS"]
+      if haskey(BLISS_group, "ovec")
+        println("Loading results for BLISS optimization from $SAVENAME")
+        ovec = read(BLISS_group, "ovec")
+        tvec = read(BLISS_group, "tvec")
+        pvec = read(BLISS_group, "pvec")
+        close(fid)
+        S = hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, F.N)
+        close(fid)
+        return F - S
+      end
+    end
+    close(fid)
+  end
+
+  L = Int(F.N * (F.N + 1) / 2)
+  x0 = zeros(2L + 5)
+
+  if F.spin_orb == true
+    n_qubits = F.N
+  else
+    n_qubits = 2 * F.N
+  end
+  Sz = Sz_builder(n_qubits)
+  S2 = S2_builder(n_qubits)
+
+
+  function cost(x)
+    return PAULI_L1(F - hubbard_bliss_sym_params_to_F_OP(x[1:L], x[L+1:2L], x[2L+1:end], η, sz, s2, F.N))
+  end
+
+  if verbose
+    println("Starting 1-norm cost:")
+    @show cost(x0)
+    @time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol=1e-3))
+    println("Final 1-norm cost:")
+    @show sol.minimum
+  else
+    sol = optimize(cost, x0, BFGS())
+  end
+
+  xsol = sol.minimizer
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    create_group(fid, "BLISS")
+    BLISS_group = fid["BLISS"]
+    println("Saving results of BLISS optimization to $SAVENAME")
+    BLISS_group["ovec"] = xsol[1:L]
+    BLISS_group["pvec"] = xsol[L+1:2L]
+    BLISS_group["tvec"] = xsol[2L+1:end]
+    close(fid)
+  end
+  S = hubbard_bliss_sym_params_to_F_OP(xsol[1:L], xsol[L+1:2L], xsol[2L+1:end], η, sz, s2, F.N)
+
+  return F - S
+end
+
+
+function symmetrize_O_ij(o_opt, N)
+  idx = 1
+  O = zeros(2, N, N)
+  for s = 1:2
+    for i = 1:N
+      for j = 1:N
+        O[s, i, j] = o_opt[idx]
+        idx += 1
+      end
+    end
+  end
+
+
+  O_sym = zeros(2, N, N)
+  for s = 1:2
+    for i = 1:N
+      for j = 1:N
+        O_sym[s, i, j] = (O[s, i, j] + O[s, j, i]) / 2
+      end
+    end
+  end
+
+  return O_sym
+end
+
+
+
+"""
+bliss_linprog(F :: F_OP, η; model='highs', verbose=true,SAVELOAD = SAVING, SAVENAME=DATAFOLDER*'BLISS.h5')
+Shifts the Hamiltonian by a Symmetry operator, leaving unchanged a subspace with a chosen number of electrons η, such that the L1 norm of the resultant Hamiltonian is minimised.
+Optimizes L1-norm through linear programming.
+Solvers: HiGHS and Ipopt (HiGHS is usually faster, both are expected to return identical results)
+Input:
+  The tensors of the input Hamiltonian are assumed to be of the form ``H = E0 + \\sum_{ij} h_{ij} a_i^† a_j + \\sum_{ijkl} g_ijkl a_i^† a_j a_k^† a_l``
+  
+  F::F_OP : (F_OP is defined under src/UTILS/struct.jl)
+  
+    Case 1: F respects spin symmetry, i.e., αα and ββ type components of one-body tensor are identical, and, αααα, ααββ, ββαα and ββββ type components of two body tensor are identical.
+      If N be the number of spatial orbitals, F.mbts[2] (i.e. the one body tensor) is an N * N object, and F.mbts[3] (i.e. the two body tensor) is an 				N*N*N*N object, with indices running over spatial orbitals.
+      
+    Case 2: F may violate spin symmetry, i.e., αα and ββ type components of one-body tensor are not necessarily identical, and αααα, ααββ, ββαα and ββββ type components of two body tensor are not necessarily identical. 
+      If N be the number of spatial orbitals, F.mbts[2] (i.e. the one body tensor) is a 2*N*N object, and F.mbts[3] (i.e. the two body tensor) is a 4*N*N*N*N object. In both one and two body tensors, all indices except the first index run over spatial orbitals. The first index of F.mbts[2] runs over the component types αα and ββ, whereas that of F.mbts[3] runs over the component types αααα, ααββ, ββαα and ββββ. 
+      
+    *NOTE*
+      bliss_linprog() does not work with F_OP where indices run over spin orbitals. Such an input F_OP would result in an incorrect output.
+      One can convert from the F_OP format where indices run over spin-orbitals to the format described under Case 2 using the F_OP_compress(F::F_OP) function. To convert back to the F_OP format where indices run over spin-orbitals, use the F_OP_converter(F::F_OP) function. Both F_OP_compress() and F_OP_converter() functions are defined under src/UTILS/fermionic.jl.
+      
+  η::Int64 : Number of electrons. The subspace corresponding to η electrons is left invariant under BLISS. 
+  model: can be set as 'highs' or 'ipopt'. Set to 'highs' by default.
+  verbose: whether intermediate step calculations are displayed or not
+  SAVELOAD: whether output is saved under SAVED/ folder and whether previously computed results are loaded from savefiles or not. Set to the configuration variable SAVING by dafault.
+  SAVENAME: filename for the savefile of the BLISS results. 
+Output: 
+  Returns the BLISS-treated Hamiltonian F_bliss and the Symmetry shift operator S, where F_bliss = F - S, F being the input F_OP. 
+  The format of the one and two body tensors in the output F_OP objects (i.e. F_bliss and S) are exactly identical to that of their input. 	
+"""
+
+function bliss_linprog(F::F_OP, η; model="highs", verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5", num_threads::Int=1)
+  if F.spin_orb
+    error("BLISS not defined for spin-orb=true!")
+  end
+
+  if model == "highs"
+    L1_OPT = Model(HiGHS.Optimizer)
+  elseif model == "ipopt"
+    L1_OPT = Model(Ipopt.Optimizer)
+  else
+    error("Not defined for model = $model")
+  end
+
+  if num_threads > 1
+    HiGHS.Highs_resetGlobalScheduler(1)
+    set_attribute(L1_OPT, JuMP.MOI.NumberOfThreads(), num_threads)
+  end
+
+  if verbose == false
+    set_silent(L1_OPT)
+  end
+
+  # println("The L1 cost of original Hamiltonian is: ",PAULI_L1(F))
+
+  if size(F.mbts[2], 1) == size(F.mbts[3], 1)
+    if SAVELOAD
+      fid = h5open(SAVENAME, "cw")
+      if haskey(fid, "BLISS")
+        BLISS_group = fid["BLISS"]
+        if haskey(BLISS_group, "ovec")
+          println("Loading results for BLISS optimization from $SAVENAME")
+          ovec = read(BLISS_group, "ovec")
+          t1 = read(BLISS_group, "t1")
+          t2 = read(BLISS_group, "t2")
+          t_opt = [t1, t2]
+          O = zeros(F.N, F.N)
+          idx = 1
+          for i = 1:F.N
+            for j = 1:F.N
+              O[i, j] = ovec[idx]
+              idx += 1
+            end
+          end
+          @show t_opt
+          @show O
+          ham = fid["BLISS_HAM"]
+          F_new = F_OP((read(ham, "h_const"), read(ham, "obt"), read(ham, "tbt")))
+          # println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+          close(fid)
+          return F_new, F - F_new
+        end
+      end
+      close(fid)
     end
 
-    ovec_len = Int(F.N*(F.N+1)/2)
+
+    ovec_len = Int(F.N * (F.N + 1) / 2)
 
     ν1_len = F.N^2
     ν2_len = F.N^4
-    ν3_len = Int((F.N*(F.N-1)/2)^2)
-    
+    ν3_len = Int((F.N * (F.N - 1) / 2)^2)
+
     @variables(L1_OPT, begin
-        t[1:2]
-        obt[1:ν1_len]
-        tbt1[1:ν2_len]
-        tbt2[1:ν3_len]
-        omat[1:F.N^2]
+      t[1:2]
+      obt[1:ν1_len]
+      tbt1[1:ν2_len]
+      tbt2[1:ν3_len]
+      omat[1:F.N^2]
     end)
 
-    @objective(L1_OPT, Min, sum(obt)+sum(tbt1)+sum(tbt2))
-    
+    @objective(L1_OPT, Min, sum(obt) + sum(tbt1) + sum(tbt2))
+
 
     obt_corr = ob_correction(F)
     #1-body 1-norm
     λ1 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx += 1
-    		λ1[idx] = F.mbts[2][i,j] + obt_corr[i,j]
-    	end
+      for j in 1:F.N
+        idx += 1
+        λ1[idx] = F.mbts[2][i, j] + obt_corr[i, j]
+      end
     end
 
     τ_11 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx += 1
-    		if i == j
-    			τ_11[idx] = 2*F.N
-    		end
-    	end
+      for j in 1:F.N
+        idx += 1
+        if i == j
+          τ_11[idx] = F.N
+        end
+      end
     end
     τ_12 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx += 1
-    		if i == j
-    			τ_12[idx] = 1
-    		end
-    	end
+      for j in 1:F.N
+        idx += 1
+        if i == j
+          τ_12[idx] = 1
+        end
+      end
     end
-    T1 = zeros(ν1_len,ν1_len)
-    T1 += Diagonal((2η - 2F.N)*ones(ν1_len))
+    T1 = zeros(ν1_len, ν1_len)
+    T1 += Diagonal((η - F.N) * ones(ν1_len))
     idx1 = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx1 += 1
-    		idx2 = 0
-    		for k in 1:F.N
-    			for l in 1:F.N
-    				idx2 += 1
-    				if i == j && k == l
- 	   					T1[idx1,idx2] -= 2
- 	   				end
- 	   			end
- 	   		end
- 	   	end
- 	end
- 	
- 	
- 	@constraint(L1_OPT, low_1, λ1 - τ_11*t[1] - τ_12*t[2] + T1*omat - obt .<= 0)
-	@constraint(L1_OPT, high_1, λ1 - τ_11*t[1] - τ_12*t[2] + T1*omat + obt .>= 0)
-	
- 	#2-body αβ/βα 1-norm
- 	λ2 = zeros(ν2_len)
+      for j in 1:F.N
+        idx1 += 1
+        idx2 = 0
+        for k in 1:F.N
+          for l in 1:F.N
+            idx2 += 1
+            if i == j && k == l
+              T1[idx1, idx2] -= 1
+            end
+          end
+        end
+      end
+    end
+
+
+    @constraint(L1_OPT, low_1, λ1 - τ_11 * t[1] - τ_12 * t[2] + T1 * omat - obt .<= 0)
+    @constraint(L1_OPT, high_1, λ1 - τ_11 * t[1] - τ_12 * t[2] + T1 * omat + obt .>= 0)
+
+    #2-body αβ/βα 1-norm
+    λ2 = zeros(ν2_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:F.N
-    			for l in 1:F.N
-    				idx += 1
-    				λ2[idx] = 0.5 * F.mbts[3][i,j,k,l]
-    			end
-    		end
-    	end
+      for j in 1:F.N
+        for k in 1:F.N
+          for l in 1:F.N
+            idx += 1
+            λ2[idx] = 0.5 * F.mbts[3][i, j, k, l]
+          end
+        end
+      end
     end
 
     τ_21 = zeros(ν2_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:F.N
-    			for l in 1:F.N
-    				idx += 1
-    				if i == j && k == l
-    					τ_21[idx] = 0.5
-    				end
-    			end
-    		end
-    	end
+      for j in 1:F.N
+        for k in 1:F.N
+          for l in 1:F.N
+            idx += 1
+            if i == j && k == l
+              τ_21[idx] = 0.5
+            end
+          end
+        end
+      end
     end
 
-    T2 = zeros(ν2_len,ν1_len)
+    T2 = zeros(ν2_len, ν1_len)
     idx = 0
     idx_ij = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx_ij += 1
-    		idx_kl = 0
-    		for k in 1:F.N
-    			for l in 1:F.N
-    				idx += 1
-    				idx_kl += 1
-    				if i == j
-    					T2[idx,idx_kl] += 1
-    				end
-    				if k == l
-    					T2[idx,idx_ij] += 1
-    				end
-    			end
-    		end
-    	end
+      for j in 1:F.N
+        idx_ij += 1
+        idx_kl = 0
+        for k in 1:F.N
+          for l in 1:F.N
+            idx += 1
+            idx_kl += 1
+            if i == j
+              T2[idx, idx_kl] += 0.5
+            end
+            if k == l
+              T2[idx, idx_ij] += 0.5
+            end
+          end
+        end
+      end
     end
-    
-    @constraint(L1_OPT, low_2, λ2 - τ_21*t[1] - 0.5*T2*omat - tbt1 .<= 0)
-    @constraint(L1_OPT, high_2, λ2 - τ_21*t[1] - 0.5*T2*omat + tbt1 .>= 0)
-    
-    T_dict = zeros(Int64,F.N,F.N)
+
+    @constraint(L1_OPT, low_2, λ2 - τ_21 * t[1] - 0.5 * T2 * omat - tbt1 .<= 0)
+    @constraint(L1_OPT, high_2, λ2 - τ_21 * t[1] - 0.5 * T2 * omat + tbt1 .>= 0)
+
+    T_dict = zeros(Int64, F.N, F.N)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		idx += 1
-    		T_dict[i,j] = idx
-    	end
+      for j in 1:F.N
+        idx += 1
+        T_dict[i, j] = idx
+      end
     end
     #2-body αα/ββ 1-norm
     λ3 = zeros(ν3_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:i-1
-    			for l in 1:j-1
-    				idx += 1
-    				λ3[idx] = F.mbts[3][i,j,k,l] - F.mbts[3][i,l,k,j]
-    			end
-    		end
-    	end
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in 1:j-1
+            idx += 1
+            λ3[idx] = F.mbts[3][i, j, k, l] - F.mbts[3][i, l, k, j]
+          end
+        end
+      end
     end
-    
+
     τ_31 = zeros(ν3_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:i-1
-    			for l in 1:j-1
-    				idx += 1
-    				if i == j && k == l
-    					τ_31[idx] += 1
-    				end
-    				if i == l && k == j
-    					τ_31[idx] -= 1
-    				end
-    			end
-    		end
-    	end
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in 1:j-1
+            idx += 1
+            if i == j && k == l
+              τ_31[idx] += 1
+            end
+            if i == l && k == j
+              τ_31[idx] -= 1
+            end
+          end
+        end
+      end
     end
-    
-    
 
-    T3 = zeros(ν3_len,ν1_len)
+
+
+    T3 = zeros(ν3_len, ν1_len)
     idx = 0
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:i-1
-    			for l in 1:j-1
-    				idx += 1
-    				
-    				idx_ij = T_dict[i,j]
-    				if k == l
-    					T3[idx,idx_ij] += 1
-    				end
-    				
-    				idx_kl = T_dict[k,l]
-    				if i == j
-    					T3[idx,idx_kl] += 1
-    				end
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in 1:j-1
+            idx += 1
 
-    				idx_il = T_dict[i,l]
-    				if k == j
-    					T3[idx,idx_il] -= 1
-    				end
+            idx_ij = T_dict[i, j]
+            if k == l
+              T3[idx, idx_ij] += 0.5
+            end
 
-    				idx_kj = T_dict[k,j]
-    				if i == l
-    					T3[idx,idx_kj] -= 1
-    				end
-    			end
-    		end
-    	end
+            idx_kl = T_dict[k, l]
+            if i == j
+              T3[idx, idx_kl] += 0.5
+            end
+
+            idx_il = T_dict[i, l]
+            if k == j
+              T3[idx, idx_il] -= 0.5
+            end
+
+            idx_kj = T_dict[k, j]
+            if i == l
+              T3[idx, idx_kj] -= 0.5
+            end
+          end
+        end
+      end
     end
-   
-    @constraint(L1_OPT, low_3, λ3 - τ_31*t[1] - T3*omat - tbt2 .<= 0)
-    @constraint(L1_OPT, high_3, λ3 - τ_31*t[1] - T3*omat + tbt2 .>= 0)
-    
-    optimize!(L1_OPT)
-    
+
+    @constraint(L1_OPT, low_3, λ3 - τ_31 * t[1] - T3 * omat - tbt2 .<= 0)
+    @constraint(L1_OPT, high_3, λ3 - τ_31 * t[1] - T3 * omat + tbt2 .>= 0)
+
+    JuMP.optimize!(L1_OPT)
+
     t_opt = value.(t)
     o_opt = value.(omat)
-    
-    idx=1
-    O=zeros(F.N,F.N)
-    for i=1:F.N
-    	for j=1:F.N
-    		O[i,j]=o_opt[idx]
-    		idx+=1
-    	end
+    @show t_opt
+    idx = 1
+    O = zeros(F.N, F.N)
+    for i = 1:F.N
+      for j = 1:F.N
+        O[i, j] = o_opt[idx]
+        idx += 1
+      end
     end
-    O=(O+O')/2	
-        
-        
-    Ne,Ne2 = symmetry_builder(F)
-    
-    
-    
+    @show O
+    O = (O + O') / 2
+
+
+    Ne, Ne2 = symmetry_builder(F)
+
+
+
     s2_tbt = t_opt[1] * Ne2.mbts[3]
     for i in 1:F.N
-    	for j in 1:F.N
-    		for k in 1:F.N
-    			s2_tbt[i,j,k,k] += O[i,j]
-    			s2_tbt[k,k,i,j] += O[i,j]
-    		end
-    	end
+      for j in 1:F.N
+        for k in 1:F.N
+          s2_tbt[i, j, k, k] += O[i, j]
+          s2_tbt[k, k, i, j] += O[i, j]
+        end
+      end
     end
-    s2 = F_OP(([0],[0],s2_tbt))
+    s2 = F_OP(([0], [0], s2_tbt))
 
-    s1_obt = t_opt[2]*Ne.mbts[2] - 2η*O
-    s1 = F_OP(([0],s1_obt))
-    
+    s1_obt = t_opt[2] * Ne.mbts[2] - 2η * O
+    s1 = F_OP(([-t_opt[2] * η - t_opt[1] * η^2], s1_obt))
+    # s1 = F_OP(([-t_opt[2] * η], s1_obt))
+
     F_new = F - s1 - s2
-    if verbose == true
-    	println("Finished BLISS optimization, L1 cost reduced from $(PAULI_L1(F)) to $(PAULI_L1(F_new))")
+    # F_new = F - s1
+    println("h_const after BLISS:", F_new.mbts[1])
+    if SAVELOAD
+      fid = h5open(SAVENAME, "cw")
+      create_group(fid, "BLISS")
+      BLISS_group = fid["BLISS"]
+      println("Saving results of BLISS optimization to $SAVENAME")
+      BLISS_group["ovec"] = o_opt
+      BLISS_group["t1"] = t_opt[1]
+      BLISS_group["t2"] = t_opt[2]
+      BLISS_group["t3"] = 0
+      BLISS_group["N"] = F.N
+      BLISS_group["Ne"] = η
+      create_group(fid, "BLISS_HAM")
+      MOL_DATA = fid["BLISS_HAM"]
+      MOL_DATA["h_const"] = F_new.mbts[1]
+      MOL_DATA["obt"] = F_new.mbts[2]
+      MOL_DATA["tbt"] = F_new.mbts[3]
+      MOL_DATA["threebt"] = 0
+      MOL_DATA["eta"] = η
+      close(fid)
     end
-    
-    return F_new, s1+s2
+
+    #println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+    return F_new, s1 + s2
+  else
+
+    if SAVELOAD
+      fid = h5open(SAVENAME, "cw")
+      if haskey(fid, "BLISS")
+        BLISS_group = fid["BLISS"]
+        if haskey(BLISS_group, "ovec")
+          println("Loading results for BLISS optimization from $SAVENAME")
+          ovec = read(BLISS_group, "ovec")
+          t1 = read(BLISS_group, "t1")
+          t2 = read(BLISS_group, "t2")
+          t_opt = [t1, t2]
+          O = symmetrize_O_ij(ovec, F.N)
+          @show t_opt
+          @show O
+          ham = fid["BLISS_HAM"]
+          F_new = F_OP((read(ham, "h_const"), read(ham, "obt"), read(ham, "tbt")))
+          #println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+          close(fid)
+          return F_new, F - F_new
+        end
+      end
+      close(fid)
+    end
+
+    ovec_len = Int(F.N * (F.N + 1) / 2)
+
+
+    # The dimension for each vector that we are optimizing
+    v1_len = 2 * F.N^2
+    ν2_len = 2 * F.N^4
+    ν3_len = Int(2 * (F.N * (F.N - 1) / 2)^2)
+    v4_len = 2 * (F.N^2 * (F.N - 1) * (F.N - 2))
+    v5_len = 2 * (F.N * (F.N - 1) * (F.N - 2))^2
+
+    # Initializing the variables to be optimized
+    @variables(L1_OPT, begin
+      t[1:3]
+
+      obt[1:v1_len]
+      tbt1[1:ν2_len]
+      tbt2[1:ν3_len]
+      tbt3[1:v4_len]
+      tbt4[1:v4_len]
+      threebt[1:v5_len]
+      omat[1:2*F.N^2]
+    end)
+
+    @objective(L1_OPT, Min, 0.5 * (sum(obt) + sum(tbt1) + sum(tbt2)))
+
+    # One-body correction from the two-body term g
+    obt_corr = ob_correction(F)
+    # One-body correction from the three-body term t
+    obt_three_corr = ob_correction_3bd(F)
+
+    # Original one-body tensors without tilde
+    λ1 = zeros(2 * F.N^2)
+    idx = 0
+    for s in 1:2
+      for i in 1:F.N
+        for j in 1:F.N
+          idx += 1
+          λ1[idx] = F.mbts[2][s, i, j] + obt_corr[s, i, j] + obt_three_corr[s, i, j]
+        end
+      end
+    end
+
+    # Shift due to (Ne - ne) term
+    τ_11 = zeros(v1_len)
+    idx = 0
+    for s in 1:2
+      for i in 1:F.N
+        for j in 1:F.N
+          idx += 1
+          if i == j
+            τ_11[idx] = 1
+          end
+        end
+      end
+    end
+
+    # Shift due to (Ne^2 - ne^2) term
+    τ_12 = zeros(2 * F.N^2)
+    idx = 0
+    for s in 1:2
+      for i in 1:F.N
+        for j in 1:F.N
+          idx += 1
+          if i == j
+            τ_12[idx] = 2 * F.N
+          end
+        end
+      end
+    end
+
+    # Shift due to (Ne^3 - ne^3) term
+
+    τ_13 = zeros(2 * F.N^2)
+    idx = 0
+    for s in 1:2
+      for i in 1:F.N
+        for j in 1:F.N
+          idx += 1
+          if i == j
+            τ_13[idx] = 1
+          end
+        end
+      end
+    end
+    T1 = zeros(2 * F.N^2, 2 * F.N^2)
+    T1 += Diagonal((2η - 2F.N) * ones(2 * F.N^2))
+    idx1 = 0
+    for s in 1:2
+      for i in 1:F.N
+        for j in 1:F.N
+          idx1 += 1
+          idx2 = 0
+          for q in 1:2
+            for k in 1:F.N
+              for l in 1:F.N
+                idx2 += 1
+                if i == j && k == l
+                  T1[idx1, idx2] -= 2
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+    @constraint(L1_OPT, low_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - t_13 * t[3] + (2η - 4 * F.N) * omat - obt .<= 0)
+    @constraint(L1_OPT, high_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - t_13 * t[3] + (2η - 4 * F.N) * omat + obt .>= 0)
+
+    tbt_corr_1 = tb_correction_1(F)
+
+    λ2 = zeros(ν2_len)
+    idx = 0
+    for s in 2:3
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:F.N
+            for l in 1:F.N
+              idx += 1
+              λ2[idx] = 0.5 * F.mbts[3][s, i, j, k, l] + 0.5 * tbt_corr_1[s, i, j, k, l]
+            end
+          end
+        end
+      end
+    end
+
+    τ_21 = zeros(ν2_len)
+    idx = 0
+    for s in 2:3
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:F.N
+            for l in 1:F.N
+              idx += 1
+              if i == j && k == l
+                τ_21[idx] = 0.5
+              end
+            end
+          end
+        end
+      end
+    end
+
+    T2 = zeros(Int64, Int64(ν2_len / 2), F.N^2)
+    idx = 0
+    idx_ij = 0
+
+    for i in 1:F.N
+      for j in 1:F.N
+        idx_ij += 1
+
+
+        for k in 1:F.N
+          for l in 1:F.N
+            idx += 1
+
+            if k == l
+              T2[idx, idx_ij] += 1
+            end
+          end
+        end
+
+      end
+    end
+
+
+    @constraint(L1_OPT, low_2, λ2 - τ_21 * t[1] - vcat(T2 * omat[1:F.N^2], T2 * omat[F.N^2+1:end]) - tbt1 .<= 0)
+    @constraint(L1_OPT, high_2, λ2 - τ_21 * t[1] - vcat(T2 * omat[1:F.N^2], T2 * omat[F.N^2+1:end]) + tbt1 .>= 0)
+
+    tbt_corr_2 = tb_correction_2(F)
+
+    T_dict = zeros(Int64, F.N, F.N)
+    idx = 0
+    for i in 1:F.N
+      for j in 1:F.N
+        idx += 1
+        T_dict[i, j] = idx
+      end
+    end
+    #2-body αα/ββ 1-norm
+    λ3 = zeros(ν3_len)
+    idx = 0
+    arr_align = [1, 4]
+    arr_anti = [2, 3]
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:i-1
+            for l in j+1:F.N
+              idx += 1
+              λ3[idx] = F.mbts[3][s, i, j, k, l] - F.mbts[3][s, i, l, k, j] + tbt_corr_2[s, i, j, k, l] - tbt_corr_2[s, i, l, k, j]
+            end
+          end
+        end
+      end
+    end
+
+    τ_31 = zeros(ν3_len)
+    idx = 0
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:i-1
+            for l in j+1:F.N
+              idx += 1
+
+              if i == l && k == j
+                τ_31[idx] += 1
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+
+    T3 = zeros(Int64(ν3_len / 2), F.N^2)
+    idx = 0
+
+    for i in 1:F.N
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in j+1:F.N
+            idx += 1
+
+            idx_ij = T_dict[i, j]
+            if k == l
+              T3[idx, idx_ij] += 2
+            end
+
+
+            idx_il = T_dict[i, l]
+            if k == j
+              T3[idx, idx_il] -= 2
+            end
+
+
+          end
+        end
+      end
+    end
+
+    @constraint(L1_OPT, low_3, λ3 + τ_31 * t[1] - vcat(T3 * omat[1:F.N^2], T3 * omat[F.N^2+1:end]) - tbt2 .<= 0)
+    @constraint(L1_OPT, high_3, λ3 + τ_31 * t[1] - vcat(T3 * omat[1:F.N^2], T3 * omat[F.N^2+1:end]) + tbt2 .>= 0)
+
+    # New tbt constraint
+    tbt_corr_2 = tb_correction_2(F)
+
+    T_dict = zeros(Int64, F.N, F.N)
+    idx = 0
+    for i in 1:F.N
+      for j in 1:F.N
+        idx += 1
+        T_dict[i, j] = idx
+      end
+    end
+    λ4 = zeros(ν4_len)
+    idx = 0
+    arr_align = [1, 4]
+    arr_anti = [2, 3]
+    for s in arr_align
+      for i in 1:F.N
+        for k in 1:F.N
+          for m in 1:i-1
+            for j in j+1:F.N
+              idx += 1
+              λ4[idx] = 1 / 8 * (sum(F.mbts[4][s, i, l, k, j, m, l] + F.mbts[4][s, i, l, k, l, m, j] + F.mbts[4][s, i, j, k, l, m, l] for l in 1:F.N) + F.mbts[4][s, i, j, k, j, m, j])
+            end
+          end
+        end
+      end
+    end
+
+    τ_41 = zeros(v4_len)
+    idx = 0
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:i-1
+            for l in j+1:F.N
+              idx += 1
+
+              if i == j && k == l
+                τ_41[idx] += 1
+              end
+            end
+          end
+        end
+      end
+    end
+
+    τ_42 = zeros(v4_len)
+    idx = 0
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:i-1
+            for l in j+1:F.N
+              idx += 1
+
+              if i == j && k == l
+                τ_42[idx] += 3
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+
+    T4 = zeros(Int64(ν3_len / 2), F.N^2)
+    idx = 0
+
+    for i in 1:F.N
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in j+1:F.N
+            idx += 1
+
+            idx_ij = T_dict[i, j]
+            if k == l
+              T4[idx, idx_ij] += 2
+            end
+
+
+            idx_il = T_dict[i, l]
+            if k == j
+              T4[idx, idx_il] -= 2
+            end
+
+
+          end
+        end
+      end
+    end
+
+    @constraint(L1_OPT, low_4, λ4 + τ_41 * t[1] + τ_42 * t[3] - vcat(T4 * omat[1:F.N^2], T4 * omat[F.N^2+1:end]) - tbt3 .<= 0)
+    @constraint(L1_OPT, high_4, λ4 + τ_41 * t[1] + τ_42 * t[3] - vcat(T4 * omat[1:F.N^2], T4 * omat[F.N^2+1:end]) + tbt3 .>= 0)
+
+    # New tbt constraint 2
+    tbt_corr_2 = tb_correction_2(F)
+
+    T_dict = zeros(Int64, F.N, F.N)
+    idx = 0
+    for i in 1:F.N
+      for j in 1:F.N
+        idx += 1
+        T_dict[i, j] = idx
+      end
+    end
+    λ5 = zeros(ν4_len)
+    idx = 0
+    arr_align = [1, 4]
+    arr_anti = [2, 3]
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for l in 1:i-1
+            for n in j+1:F.N
+              idx += 1
+              λ5[idx] = 1 / 8 * (sum(-F.mbts[4][s, k, j, i, l, k, n] + F.mbts[4][s, k, j, k, l, i, n] + F.mbts[4][s, i, j, k, l, k, n] for k in 1:F.N) + F.mbts[4][s, i, j, i, l, i, n])
+            end
+          end
+        end
+      end
+    end
+
+    τ_51 = zeros(v4_len)
+    idx = 0
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:i-1
+            for l in j+1:F.N
+              idx += 1
+
+              if i == l && k == j
+                τ_51[idx] += 1
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+
+    T5 = zeros(Int64(ν3_len / 2), F.N^2)
+    idx = 0
+
+    for i in 1:F.N
+      for j in 1:F.N
+        for k in 1:i-1
+          for l in j+1:F.N
+            idx += 1
+
+            idx_ij = T_dict[i, j]
+            if k == l
+              T5[idx, idx_ij] += 2
+            end
+
+
+            idx_il = T_dict[i, l]
+            if k == j
+              T5[idx, idx_il] -= 2
+            end
+
+
+          end
+        end
+      end
+    end
+
+    @constraint(L1_OPT, low_5, λ5 + τ_51 * t[1] - vcat(T5 * omat[1:F.N^2], T5 * omat[F.N^2+1:end]) - tbt4 .<= 0)
+    @constraint(L1_OPT, high_5, λ5 + τ_51 * t[1] - vcat(T5 * omat[1:F.N^2], T5 * omat[F.N^2+1:end]) + tbt4 .>= 0)
+
+    # Three body constraint
+    tbt_corr_2 = tb_correction_2(F)
+
+    T_dict = zeros(Int64, F.N, F.N)
+    idx = 0
+    for i in 1:F.N
+      for j in 1:F.N
+        idx += 1
+        T_dict[i, j] = idx
+      end
+    end
+    λ6 = zeros(v5_len)
+    idx = 0
+    arr_align = [1, 4]
+    arr_anti = [2, 3]
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:F.N
+            for l in 1:F.N
+              for m in 1:F.N
+                for n in 1:F.N
+                  if i != k && i != m && k != m && j != l && l != n && j != n
+                    idx += 1
+                    λ6[idx] = 1 / 8 * F.mbts[4][i, j, k, l, m, n]
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    τ_61 = zeros(v5_len)
+    idx = 0
+    for s in arr_align
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:F.N
+            for l in 1:F.N
+              for m in 1:F.N
+                for n in 1:F.N
+                  idx += 1
+                  if i == j && k == l && m == n
+                    τ_61[idx] += 1
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+    @constraint(L1_OPT, low_6, λ6 + τ_61 * t[3] - threebt .<= 0)
+    @constraint(L1_OPT, high_6, λ6 + τ_61 * t[3] + threebt .>= 0)
+
+
+
+    JuMP.optimize!(L1_OPT)
+
+
+    t_opt = value.(t)
+    o_opt = value.(omat)
+    #@show t_opt
+
+
+    idx = 1
+    O = zeros(2, F.N, F.N)
+    for s = 1:2
+      for i = 1:F.N
+        for j = 1:F.N
+          O[s, i, j] = o_opt[idx]
+          idx += 1
+        end
+      end
+    end
+
+
+    O_sym = zeros(2, F.N, F.N)
+    for s = 1:2
+      for i = 1:F.N
+        for j = 1:F.N
+          O_sym[s, i, j] = (O[s, i, j] + O[s, j, i]) / 2
+        end
+      end
+    end
+
+    O = O_sym
+    #@show O
+
+
+    Ne, Ne2 = symmetry_builder(F)
+
+
+    s2_tbt = zeros(4, F.N, F.N, F.N, F.N)
+    for i = 1:4
+      s2_tbt[i, :, :, :, :] = t_opt[1] * Ne2.mbts[3]
+    end
+    #=for sigma in arr_align
+      for i in 1:F.N
+      	for j in 1:F.N
+      		for k in 1:F.N
+      			for l in 1:F.N
+      			#s2_tbt[sigma,i,j,k,k] += 2*O[div(sigma-1,2)+1,i,j]
+       			if k==l
+       				s2_tbt[sigma,i,j,k,l] += O[div(sigma-1,2)+1,i,j]
+       			end
+       			if i==j
+       				s2_tbt[sigma,k,l,i,j] += O[div(sigma-1,2)+1,k,l]
+       			end
+       		end
+      		end
+      	end
+      end
+     end
+
+     for sigma in arr_anti
+      for i in 1:F.N
+      	for j in 1:F.N
+      		for k in 1:F.N
+      			for l in 1:F.N
+      			#s2_tbt[sigma,i,j,k,k] += 2*O[div(sigma-1,2)+1,i,j]
+       			if k==l
+       				s2_tbt[sigma,i,j,k,l] += O[sigma-1,i,j]
+       			end
+       			if i==j
+       				s2_tbt[5-sigma,k,l,i,j] += O[4-sigma,k,l]
+       			end
+       		end
+      		end
+      	end
+      end
+     end=#
+
+    for sigma = 1:4
+      for i in 1:F.N
+        for j in 1:F.N
+          for k in 1:F.N
+            s2_tbt[sigma, i, j, k, k] += 2 * O[div(sigma - 1, 2)+1, i, j]
+            #s2_tbt[sigma,k,k,i,j] += O[div(sigma-1,2)+1,i,j]
+
+          end
+        end
+      end
+    end
+
+    s1_obt = zeros(2, F.N, F.N)
+    for i = 1:2
+      s1_obt[i, :, :] = t_opt[2] * Ne.mbts[2] .- 2η * O[i, :, :]
+    end
+
+    s = F_OP(([-t_opt[2] * η - t_opt[1] * η^2], s1_obt, s2_tbt))
+    #@show s
+    F_new = F - s
+
+
+    if SAVELOAD
+      fid = h5open(SAVENAME, "cw")
+      create_group(fid, "BLISS")
+      BLISS_group = fid["BLISS"]
+      println("Saving results of BLISS optimization to $SAVENAME")
+      BLISS_group["ovec"] = o_opt
+      BLISS_group["t1"] = t_opt[1]
+      BLISS_group["t2"] = t_opt[2]
+      create_group(fid, "BLISS_HAM")
+      MOL_DATA = fid["BLISS_HAM"]
+      MOL_DATA["h_const"] = F_new.mbts[1]
+      MOL_DATA["obt"] = F_new.mbts[2]
+      MOL_DATA["tbt"] = F_new.mbts[3]
+      MOL_DATA["eta"] = η
+      close(fid)
+    end
+
+
+    println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+    return F_new, s
+
+  end
+
 end
 

--- a/src/UTILS/bliss.jl
+++ b/src/UTILS/bliss.jl
@@ -1,1598 +1,804 @@
 #routines for finding fluid-body symmetry shifts
+function bliss_sym_params_to_F_OP(ovec, t1, t2, η, N = Int((sqrt(8*length(ovec)+1) - 1)/2), spin_orb=false)
+	#builds S symmetry shift corresponding to S = s0+s1+s2
+	obt = zeros(N, N)
+	idx = 0
+	for i in 1:N
+		for j in 1:i
+			idx += 1
+			obt[i,j] += ovec[idx]
+			obt[j,i] += ovec[idx]
+		end
+	end
 
-using Optim
+	s0 = [-t1*(η^2) - t2*η]
+	s1 = t2*collect(Diagonal(ones(N))) - η*obt
 
-function bliss_sym_params_to_F_OP(ovec, t1, t2, η, N=Int((sqrt(8 * length(ovec) + 1) - 1) / 2), spin_orb=false)
-  #builds S symmetry shift corresponding to S = s0+s1+s2
-  obt = zeros(N, N)
-  idx = 0
-  for i in 1:N
-    for j in 1:i
-      idx += 1
-      obt[i, j] += ovec[idx]
-      obt[j, i] += ovec[idx]
-    end
-  end
+	s2 = zeros(N,N,N,N)
+	for i in 1:N
+		for j in 1:N
+			s2[i,i,j,j] += t1
+			for k in 1:N
+				s2[i,j,k,k] += 0.5*obt[i,j]
+				s2[k,k,i,j] += 0.5*obt[i,j]
+			end
+		end
+	end
 
-  s0 = [-t1 * (η^2) - t2 * η]
-  s1 = t2 * collect(Diagonal(ones(N))) - η * obt
-
-  s2 = zeros(N, N, N, N)
-  for i in 1:N
-    for j in 1:N
-      s2[i, i, j, j] += t1
-      for k in 1:N
-        s2[i, j, k, k] += 0.5 * obt[i, j]
-        s2[k, k, i, j] += 0.5 * obt[i, j]
-      end
-    end
-  end
-
-  return F_OP((s0, s1, s2), spin_orb)
+	return F_OP((s0, s1, s2), spin_orb)
 end
 
 function quadratic_bliss_params_to_F_OP(u1, u2, ovec, η, N)
-  if length(ovec) == Int(N * (N + 1) / 2)
-    omat = zeros(N, N)
-    idx = 1
-    for i = 1:N
-      for j = i:N
-        omat[i, j] = ovec[idx]
-        omat[j, i] = ovec[idx]
-        idx += 1
-      end
-    end
+	
+	omat = zeros(N,N)
+	idx=1
+	for i=1:N
+		for j=i:N
+			omat[i,j]=ovec[idx]
+			omat[j,i]=ovec[idx]
+			idx+=1
+		end
+	end
+	
+	
+	
+	Sconst = [-η - η^2]
 
+	Sobt = zeros(N, N)
+	Tobt = zeros(N, N)
+	for i in 1:N
+		Sobt[i,i] = u1
+		for j in 1:N
+			Tobt[i,j] = -2*η*omat[i,j]
+		end
+	end
 
+	Stbt = zeros(N, N, N, N)
+	Ttbt = zeros(N, N, N, N)
 
-    Sconst = [-u1 * η - u2 * η^2]
+	for i in 1:N
+		for j in 1:N
+			Stbt[i,i,j,j] = u2
+			for k in 1:N
+				
+				Ttbt[i,j,k,k] += omat[i,j]
+				Ttbt[k,k,i,j] += omat[i,j]
+			end
+		end
+	end
 
-    Sobt = zeros(N, N)
-    Tobt = zeros(N, N)
-    for i in 1:N
-      Sobt[i, i] = u1
-      for j in 1:N
-        Tobt[i, j] = -2 * η * omat[i, j]
-      end
-    end
-
-    Stbt = zeros(N, N, N, N)
-    Ttbt = zeros(N, N, N, N)
-
-    for i in 1:N
-      for j in 1:N
-        Stbt[i, i, j, j] = u2
-        for k in 1:N
-
-          Ttbt[i, j, k, k] += omat[i, j]
-          Ttbt[k, k, i, j] += omat[i, j]
-        end
-      end
-    end
-
-    S = F_OP((Sconst, Sobt, Stbt))
-    T = F_OP(([0], Tobt, Ttbt))
-    ST = S + T
-    return ST
-  else
-    idx = 1
-    O = zeros(2, N, N)
-    for s = 1:2
-      for i = 1:N
-        for j = i:N
-          O[s, i, j] = ovec[idx]
-          O[s, j, i] = ovec[idx]
-          idx += 1
-        end
-      end
-    end
-
-
-    Ne, Ne2 = symmetry_builder(N)
-
-
-    s2_tbt = zeros(4, N, N, N, N)
-    for i = 1:4
-      s2_tbt[i, :, :, :, :] = u2 * Ne2.mbts[3]
-    end
-
-    for sigma = 1:4
-      for i in 1:N
-        for j in 1:N
-          for k in 1:N
-            s2_tbt[sigma, i, j, k, k] += 2 * O[div(sigma - 1, 2)+1, i, j]
-            #s2_tbt[sigma,k,k,i,j] += O[div(sigma-1,2)+1,i,j]
-
-          end
-        end
-      end
-    end
-
-    s1_obt = zeros(2, N, N)
-    for i = 1:2
-      s1_obt[i, :, :] = u1 * Ne.mbts[2] .- 2η * O[i, :, :]
-    end
-
-    S = F_OP(([-u1 * η - u2 * η^2], s1_obt, s2_tbt))
-    return S
-  end
-
+	S = F_OP((Sconst, Sobt, Stbt))
+	T = F_OP(([0], Tobt, Ttbt))
+	ST = S+T
+	return ST
 end
 
 
 function bliss_linprog_params_to_F_OP(u1, u2, ovec, η, N)
+	
+	omat = zeros(N,N)
+	idx=1
+	for i=1:N
+		for j=i:N
+			omat[i,j]=ovec[idx]
+			omat[j,i]=ovec[idx]
+			idx+=1
+		end
+	end
+	
+	
+	
+	Sconst = [-η - η^2]
 
-  omat = zeros(N, N)
-  idx = 1
-  for i = 1:N
-    for j = i:N
-      omat[i, j] = ovec[idx]
-      omat[j, i] = ovec[idx]
-      idx += 1
-    end
-  end
+	Sobt = zeros(N, N)
+	Tobt = zeros(N, N)
+	for i in 1:N
+		Sobt[i,i] = u1
+		for j in 1:N
+			Tobt[i,j] = -η*omat[i,j]
+		end
+	end
 
+	Stbt = zeros(N, N, N, N)
+	Ttbt = zeros(N, N, N, N)
 
+	for i in 1:N
+		for j in 1:N
+			Stbt[i,i,j,j] = u2
+			for k in 1:N
+				
+				Ttbt[i,j,k,k] += 0.5*omat[i,j]
+				Ttbt[k,k,i,j] += 0.5*omat[i,j]
+			end
+		end
+	end
 
-  Sconst = [-η - η^2]
-
-  Sobt = zeros(N, N)
-  Tobt = zeros(N, N)
-  for i in 1:N
-    Sobt[i, i] = u1
-    for j in 1:N
-      Tobt[i, j] = -η * omat[i, j]
-    end
-  end
-
-  Stbt = zeros(N, N, N, N)
-  Ttbt = zeros(N, N, N, N)
-
-  for i in 1:N
-    for j in 1:N
-      Stbt[i, i, j, j] = u2
-      for k in 1:N
-
-        Ttbt[i, j, k, k] += 0.5 * omat[i, j]
-        Ttbt[k, k, i, j] += 0.5 * omat[i, j]
-      end
-    end
-  end
-
-  S = F_OP((Sconst, Sobt, Stbt))
-  T = F_OP(([0], Tobt, Ttbt))
-  ST = S + T
-  return ST
+	S = F_OP((Sconst, Sobt, Stbt))
+	T = F_OP(([0], Tobt, Ttbt))
+	ST = S+T
+	return ST
 end
+	
 
+function quadratic_ss(F :: F_OP, η)
+	hij = F.mbts[2]
+	gijkl = F.mbts[3]
 
-function quadratic_ss(F::F_OP, η)
-  hij = F.mbts[2]
-  gijkl = F.mbts[3]
+	H = sum([hij[i,i] for i in 1:F.N])
+	G = sum([gijkl[i,i,j,j] for i in 1:F.N, j in 1:F.N])
 
-  H = sum([hij[i, i] for i in 1:F.N])
-  G = sum([gijkl[i, i, j, j] for i in 1:F.N, j in 1:F.N])
+	G1 = 0.0
+	for i in 1:F.N
+		for j in 1:i-1
+			G1 += gijkl[i,j,j,i] - gijkl[i,i,j,j]
+		end
+	end
 
-  G1 = 0.0
-  for i in 1:F.N
-    for j in 1:i-1
-      G1 += gijkl[i, j, j, i] - gijkl[i, i, j, j]
-    end
-  end
+	u2 = 4*(G + G1/2)/(5*(F.N^2) - F.N)
+	u1 = (H + 2G - 2*(F.N^2)*u2)/F.N
 
-  u2 = 4 * (G + G1 / 2) / (5 * (F.N^2) - F.N)
-  u1 = (H + 2G - 2 * (F.N^2) * u2) / F.N
+	Sconst = [-η - η^2]
 
-  Sconst = [-η - η^2]
+	Sobt = zeros(F.N, F.N)
+	for i in 1:F.N
+		Sobt[i,i] = u1
+	end
 
-  Sobt = zeros(F.N, F.N)
-  for i in 1:F.N
-    Sobt[i, i] = u1
-  end
+	Stbt = zeros(F.N, F.N, F.N, F.N)
+	
+	for i in 1:F.N
+		for j in 1:F.N
+			Stbt[i,i,j,j] = u2
+		end
+	end
 
-  Stbt = zeros(F.N, F.N, F.N, F.N)
+	S = F_OP((Sconst, Sobt, Stbt))
 
-  for i in 1:F.N
-    for j in 1:F.N
-      Stbt[i, i, j, j] = u2
-    end
-  end
-
-  S = F_OP((Sconst, Sobt, Stbt))
-
-  return F - S
+	return F - S
 end
 
 
 
 function quadratic_bliss(F, η)
-  hij = F.mbts[2]
-  gijkl = F.mbts[3]
+	hij = F.mbts[2]
+	gijkl = F.mbts[3]
 
-  H = sum([hij[i, i] for i in 1:F.N])
-  G = sum([gijkl[i, i, j, j] for i in 1:F.N, j in 1:F.N])
+	H = sum([hij[i,i] for i in 1:F.N])
+	G = sum([gijkl[i,i,j,j] for i in 1:F.N, j in 1:F.N])
 
-  G1 = 0.0
+	G1 = 0.0
+	
 
+	for i in 1:F.N
+		for j in 1:i-1
+			G1 += gijkl[i,j,j,i] - gijkl[i,i,j,j]
+		end
+	end
 
-  for i in 1:F.N
-    for j in 1:i-1
-      G1 += gijkl[i, j, j, i] - gijkl[i, i, j, j]
-    end
-  end
+	Gnm = zeros(F.N, F.N)
+	
+	
+	Gtilde_nm = zeros(F.N, F.N)
+	Htilde_nm = zeros(F.N, F.N)
 
-  Gnm = zeros(F.N, F.N)
+	for n in 1:F.N
+		for m in 1:F.N
+			Gnm[n,m] = sum([gijkl[n,m,k,k] for k in 1:F.N])
+			
+			for k in 1:F.N
+				if k != n && k != m
+					Gtilde_nm[n,m] += gijkl[n,k,k,m] - gijkl[n,m,k,k]
+				end
+			end
+			Htilde_nm[n,m] = 4*(η-F.N)*(hij[n,m] + 2*Gnm[n,m]) - 2*Gnm[n,m] + 2*Gtilde_nm[n,m]
+		end
+	end
 
+	omat = zeros(F.N, F.N)
+	for i in 1:F.N
+		for j in i+1:F.N
+			omat[i,j] = omat[j,i] = -Htilde_nm[i,j]/(8(η-F.N)^2+2F.N+2(F.N-2))
+		end
+	end
 
-  Gtilde_nm = zeros(F.N, F.N)
-  Htilde_nm = zeros(F.N, F.N)
+	α = 8*(η-F.N)^2+4(F.N-1)
+	β = 24F.N-16η+4
+	γ = 8F.N-4η
+	δ = 16F.N^2-8η*F.N+4F.N-2
 
-  for n in 1:F.N
-    for m in 1:F.N
-      Gnm[n, m] = sum([gijkl[n, m, k, k] for k in 1:F.N])
+	Htilde_n = zeros(F.N)
+	for n in 1:F.N
+		Htilde_n[n] = 4*(η-F.N)*(hij[n,n] + 2*Gnm[n,n]) + 2*Gtilde_nm[n,n] - 2*Gnm[n,n]
+	end
 
-      for k in 1:F.N
-        if k != n && k != m
-          Gtilde_nm[n, m] += gijkl[n, k, k, m] - gijkl[n, m, k, k]
-        end
-      end
-      Htilde_nm[n, m] = 4 * (η - F.N) * (hij[n, m] + 2 * Gnm[n, m]) - 2 * Gnm[n, m] + 2 * Gtilde_nm[n, m]
-    end
-  end
+	μ1 = -2/F.N
+	μ2 = (2G1-G)/(F.N*(1-2F.N))
+	λ1 = (H+2*G)/F.N
+	λ2 = -2*F.N
+	λ3 = 2*(η-2*F.N)/F.N
 
-  omat = zeros(F.N, F.N)
-  for i in 1:F.N
-    for j in i+1:F.N
-      omat[i, j] = omat[j, i] = -Htilde_nm[i, j] / (8(η - F.N)^2 + 2F.N + 2(F.N - 2))
-    end
-  end
+	ee = β+γ*λ1*μ1+γ*λ3+δ*μ1
+	Htt_n = zeros(F.N)
+	for n in 1:F.N
+		Htt_n[n] = Htilde_n[n]-4H-8G + γ*(λ1+λ2*μ2) + δ*μ2
+	end
 
-  α = 8 * (η - F.N)^2 + 4(F.N - 1)
-  β = 24F.N - 16η + 4
-  γ = 8F.N - 4η
-  δ = 16F.N^2 - 8η * F.N + 4F.N - 2
+	Htt = sum(Htt_n)
+	Osum = -Htt/(α+ee*F.N)
 
-  Htilde_n = zeros(F.N)
-  for n in 1:F.N
-    Htilde_n[n] = 4 * (η - F.N) * (hij[n, n] + 2 * Gnm[n, n]) + 2 * Gtilde_nm[n, n] - 2 * Gnm[n, n]
-  end
+	for n in 1:F.N
+		omat[n,n] = -(Htt_n[n] + Osum*ee)/α
+	end
 
-  μ1 = -2 / F.N
-  μ2 = (2G1 - G) / (F.N * (1 - 2F.N))
-  λ1 = (H + 2 * G) / F.N
-  λ2 = -2 * F.N
-  λ3 = 2 * (η - 2 * F.N) / F.N
+	u2 = μ1*Osum + μ2
+	u1 = λ1 + λ2*u2 + λ3*Osum
+	
 
-  ee = β + γ * λ1 * μ1 + γ * λ3 + δ * μ1
-  Htt_n = zeros(F.N)
-  for n in 1:F.N
-    Htt_n[n] = Htilde_n[n] - 4H - 8G + γ * (λ1 + λ2 * μ2) + δ * μ2
-  end
+	Sconst = [-η - η^2]
 
-  Htt = sum(Htt_n)
-  Osum = -Htt / (α + ee * F.N)
+	Sobt = zeros(F.N, F.N)
+	Tobt = zeros(F.N, F.N)
+	for i in 1:F.N
+		Sobt[i,i] = u1
+		for j in 1:F.N
+			Tobt[i,j] = -2*η*omat[i,j]
+		end
+	end
 
-  for n in 1:F.N
-    omat[n, n] = -(Htt_n[n] + Osum * ee) / α
-  end
+	Stbt = zeros(F.N, F.N, F.N, F.N)
+	Ttbt = zeros(F.N, F.N, F.N, F.N)
 
-  u2 = μ1 * Osum + μ2
-  u1 = λ1 + λ2 * u2 + λ3 * Osum
+	for i in 1:F.N
+		for j in 1:F.N
+			Stbt[i,i,j,j] = u2
+			for k in 1:F.N
+				Ttbt[i,j,k,k] += omat[i,j]
+				Ttbt[k,k,i,j] += omat[i,j]
+			end
+		end
+	end
+	
+	S = F_OP((Sconst, Sobt, Stbt))
+	T = F_OP(([0], Tobt, Ttbt))
 
+	FT = F - S - T
+	@show PAULI_L2(FT)
+	@show PAULI_L1(FT)
+	
 
-  Sconst = [-η - η^2]
-
-  Sobt = zeros(F.N, F.N)
-  Tobt = zeros(F.N, F.N)
-  for i in 1:F.N
-    Sobt[i, i] = u1
-    for j in 1:F.N
-      Tobt[i, j] = -2 * η * omat[i, j]
-    end
-  end
-
-  Stbt = zeros(F.N, F.N, F.N, F.N)
-  Ttbt = zeros(F.N, F.N, F.N, F.N)
-
-  for i in 1:F.N
-    for j in 1:F.N
-      Stbt[i, i, j, j] = u2
-      for k in 1:F.N
-        Ttbt[i, j, k, k] += omat[i, j]
-        Ttbt[k, k, i, j] += omat[i, j]
-      end
-    end
-  end
-
-  S = F_OP((Sconst, Sobt, Stbt))
-  T = F_OP(([0], Tobt, Ttbt))
-
-  FT = F - S - T
-  @show PAULI_L2(FT)
-  @show PAULI_L1(FT)
-
-
-  return FT
+	return FT
 end
 
-function bliss_optimizer(F::F_OP, η; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
-  if SAVELOAD
-    fid = h5open(SAVENAME, "cw")
-    if haskey(fid, "BLISS")
-      BLISS_group = fid["BLISS"]
-      if haskey(BLISS_group, "ovec")
-        println("Loading results for BLISS optimization from $SAVENAME")
-        ovec = read(BLISS_group, "ovec")
-        t1 = read(BLISS_group, "t1")
-        t2 = read(BLISS_group, "t2")
-        close(fid)
+function bliss_optimizer(F :: F_OP, η; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
+	if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		if haskey(fid, "BLISS")
+			BLISS_group = fid["BLISS"]
+			if haskey(BLISS_group, "ovec")
+				println("Loading results for BLISS optimization from $SAVENAME")
+				ovec = read(BLISS_group,"ovec")
+				t1 = read(BLISS_group,"t1")
+				t2 = read(BLISS_group,"t2")
+				close(fid)
 
-        S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
-        close(fid)
-        return F - S
-      end
-    end
-    close(fid)
-  end
+				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
+				close(fid)
+				return F-S
+			end
+		end
+		close(fid)
+	end
 
-  L = Int(F.N * (F.N + 1) / 2)
-  x0 = zeros(L + 2)
+	L = Int(F.N*(F.N+1)/2)
+	x0 = zeros(L + 2)
 
-  function cost(x)
-    return PAULI_L1(F - bliss_sym_params_to_F_OP(x[3:end], x[1], x[2], η, F.N, F.spin_orb))
-  end
+	function cost(x)
+		return PAULI_L1(F - bliss_sym_params_to_F_OP(x[3:end], x[1], x[2], η, F.N, F.spin_orb))
+	end
 
-  if verbose
-    println("Starting 1-norm cost:")
-    @show cost(x0)
-    @time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol=1e-3))
-    println("Final 1-norm cost:")
-    @show sol.minimum
-  else
-    sol = optimize(cost, x0, BFGS())
-  end
+	if verbose
+		println("Starting 1-norm cost:")
+		@show cost(x0)
+		@time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol = 1e-3))
+		println("Final 1-norm cost:")
+		@show sol.minimum
+	else
+		sol = optimize(cost, x0, BFGS())
+	end
 
-  xsol = sol.minimizer
-  if SAVELOAD
-    fid = h5open(SAVENAME, "cw")
-    create_group(fid, "BLISS")
-    BLISS_group = fid["BLISS"]
-    println("Saving results of BLISS optimization to $SAVENAME")
-    BLISS_group["ovec"] = xsol[3:end]
-    BLISS_group["t1"] = xsol[1]
-    BLISS_group["t2"] = xsol[2]
-    close(fid)
-  end
-  S = bliss_sym_params_to_F_OP(xsol[3:end], xsol[1], xsol[2], η, F.N, F.spin_orb)
+	xsol = sol.minimizer
+	if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		create_group(fid, "BLISS")
+		BLISS_group = fid["BLISS"]
+		println("Saving results of BLISS optimization to $SAVENAME")
+		BLISS_group["ovec"] = xsol[3:end]
+		BLISS_group["t1"] = xsol[1]
+		BLISS_group["t2"] = xsol[2]
+		close(fid)
+	end
+	S = bliss_sym_params_to_F_OP(xsol[3:end], xsol[1], xsol[2], η, F.N, F.spin_orb)
 
-  return F - S
+	return F - S
 end
 
-function quadratic_bliss_optimizer(F::F_OP, η; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
-  #=if SAVELOAD
-  		fid = h5open(SAVENAME, "cw")
-  		if haskey(fid, "BLISS")
-  			BLISS_group = fid["BLISS"]
-  			if haskey(BLISS_group, "ovec")
-  				println("Loading results for BLISS optimization from $SAVENAME")
-  				ovec = read(BLISS_group,"ovec")
-  				t1 = read(BLISS_group,"t1")
-  				t2 = read(BLISS_group,"t2")
-  				close(fid)
-  				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
-  				close(fid)
-  				return F-S
-  			end
-  		end
-  		close(fid)
-  	end=#
-  if size(F.mbts[2], 1) == size(F.mbts[3], 1)
-    L = Int(F.N * (F.N + 1) / 2)
-  else
-    L = F.N * (F.N + 1)
-  end
-  x0 = zeros(L + 2)
+function quadratic_bliss_optimizer(F :: F_OP, η; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
+	#=if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		if haskey(fid, "BLISS")
+			BLISS_group = fid["BLISS"]
+			if haskey(BLISS_group, "ovec")
+				println("Loading results for BLISS optimization from $SAVENAME")
+				ovec = read(BLISS_group,"ovec")
+				t1 = read(BLISS_group,"t1")
+				t2 = read(BLISS_group,"t2")
+				close(fid)
+				S = bliss_sym_params_to_F_OP(ovec, t1, t2, η, F.N, F.spin_orb)
+				close(fid)
+				return F-S
+			end
+		end
+		close(fid)
+	end=#
+	L = Int(F.N*(F.N+1)/2)
+	x0 = zeros(L + 2)
+	
+	
+	function cost(x)
+		#@show quadratic_bliss_gradient(x, F, η, F.N)
+		return PAULI_L1(F - quadratic_bliss_params_to_F_OP(x[1], x[2], x[3:end], η, F.N))
+	end
+	
+	#=function grad!(storage,x)
+		storage.=quadratic_bliss_gradient(x, F, η, F.N)
+	end=#
+	
+	if verbose
+		println("Starting 1-norm cost:")
+		@show cost(x0)
+		@time sol = optimize(cost,  x0, BFGS(), Optim.Options(show_trace=false, extended_trace=true, show_every=1, f_tol = 1e-3))
+		println("Final 1-norm cost:")
+		@show sol.minimum
+	else
+		sol = optimize(cost, x0, BFGS())
+	end
+	
+	@show xsol = sol.minimizer
+	#=if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		create_group(fid, "BLISS")
+		BLISS_group = fid["BLISS"]
+		println("Saving results of BLISS optimization to $SAVENAME")
+		BLISS_group["ovec"] = xsol[3:end]
+		BLISS_group["t1"] = xsol[1]
+		BLISS_group["t2"] = xsol[2]
+		close(fid)
+	end=#
+	ST = quadratic_bliss_params_to_F_OP(xsol[1], xsol[2], xsol[3:end], η, F.N)
 
-
-  function cost(x)
-    #@show quadratic_bliss_gradient(x, F, η, F.N)
-    return PAULI_L1(F - quadratic_bliss_params_to_F_OP(x[1], x[2], x[3:end], η, F.N))
-  end
-
-  #=function grad!(storage,x)
-  		storage.=quadratic_bliss_gradient(x, F, η, F.N)
-  	end=#
-
-  if verbose
-    println("Starting 1-norm cost:")
-    @show cost(x0)
-    @time sol = Optim.optimize(cost, x0, BFGS(), Optim.Options(show_trace=false, extended_trace=true, show_every=1, f_tol=1e-3))
-    println("Final 1-norm cost:")
-    @show sol.minimum
-  else
-    sol = optimize(cost, x0, BFGS())
-  end
-
-  @show xsol = sol.minimizer
-  #=if SAVELOAD
-  		fid = h5open(SAVENAME, "cw")
-  		create_group(fid, "BLISS")
-  		BLISS_group = fid["BLISS"]
-  		println("Saving results of BLISS optimization to $SAVENAME")
-  		BLISS_group["ovec"] = xsol[3:end]
-  		BLISS_group["t1"] = xsol[1]
-  		BLISS_group["t2"] = xsol[2]
-  		close(fid)
-  	end=#
-  ST = quadratic_bliss_params_to_F_OP(xsol[1], xsol[2], xsol[3:end], η, F.N)
-
-  return F - ST
+	return F - ST
 end
 
 function Sz_builder(n_qubit)
-  Sz = zeros(n_qubit, n_qubit)
-  for i in 1:n_qubit
-    if i % 2 == 1
-      Sz[i, i] = 1
-    else
-      Sz[i, i] = -1
-    end
-  end
+	Sz = zeros(n_qubit, n_qubit)
+	for i in 1:n_qubit
+		if i%2 == 1
+			Sz[i,i] = 1
+		else
+			Sz[i,i] = -1
+		end
+	end
 
-  return Sz
+	return Sz
 end
 
 function S2_builder(n_qubit)
-  S2_tbt = zeros(n_qubit, n_qubit, n_qubit, n_qubit)
-  n_orbs = Int(n_qubit / 2)
-  for i in 1:n_orbs
-    ka = 2i - 1
-    kb = 2i
-    S2_tbt[ka, ka, ka, ka] += 1
-    S2_tbt[kb, kb, kb, kb] += 1
-    S2_tbt[ka, ka, kb, kb] += -1
-    S2_tbt[kb, kb, ka, ka] += -1
-    S2_tbt[ka, kb, kb, ka] += 2
-    S2_tbt[kb, ka, ka, kb] += 2
-  end
+	S2_tbt = zeros(n_qubit,n_qubit,n_qubit,n_qubit)
+	n_orbs = Int(n_qubit/2)
+	for i in 1:n_orbs
+		ka = 2i-1
+		kb = 2i
+		S2_tbt[ka,ka,ka,ka] += 1
+		S2_tbt[kb,kb,kb,kb] += 1
+		S2_tbt[ka,ka,kb,kb] += -1
+		S2_tbt[kb,kb,ka,ka] += -1
+		S2_tbt[ka,kb,kb,ka] += 2
+		S2_tbt[kb,ka,ka,kb] += 2
+	end
 
-  for i in 1:n_orbs
-    for j in 1:n_orbs
-      if i != j
-        ka = 2i - 1
-        kb = 2i
-        la = 2j - 1
-        lb = 2j
-        S2_tbt[ka, kb, lb, la] += 1
-        S2_tbt[lb, la, ka, kb] += 1
-        S2_tbt[kb, ka, la, lb] += 1
-        S2_tbt[la, lb, kb, ka] += 1
-        S2_tbt[ka, ka, la, la] += 0.5
-        S2_tbt[la, la, ka, ka] += 0.5
-        S2_tbt[kb, kb, lb, lb] += 0.5
-        S2_tbt[lb, lb, kb, kb] += 0.5
-        S2_tbt[ka, ka, lb, lb] += -0.5
-        S2_tbt[lb, lb, ka, ka] += -0.5
-        S2_tbt[kb, kb, la, la] += -0.5
-        S2_tbt[la, la, kb, kb] += -0.5
-      end
-    end
-  end
+	for i in 1:n_orbs
+		for j in 1:n_orbs
+			if i != j
+				ka = 2i-1
+				kb = 2i
+				la = 2j-1
+				lb = 2j
+				S2_tbt[ka,kb,lb,la] += 1
+				S2_tbt[lb,la,ka,kb] += 1
+				S2_tbt[kb,ka,la,lb] += 1
+				S2_tbt[la,lb,kb,ka] += 1
+				S2_tbt[ka,ka,la,la] += 0.5
+				S2_tbt[la,la,ka,ka] += 0.5
+				S2_tbt[kb,kb,lb,lb] += 0.5
+				S2_tbt[lb,lb,kb,kb] += 0.5
+				S2_tbt[ka,ka,lb,lb] += -0.5
+				S2_tbt[lb,lb,ka,ka] += -0.5
+				S2_tbt[kb,kb,la,la] += -0.5
+				S2_tbt[la,la,kb,kb] += -0.5
+			end
+		end
+	end
 
-  S2_tbt /= 4
+	S2_tbt /= 4
 
-  return S2_tbt
+	return S2_tbt
 end
 
-function hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, N=Int((sqrt(8 * length(ovec) + 1) - 1) / 2), Sz=Sz_builder(N), S2=S2_builder(N))
-  #builds S symmetry shift corresponding to S = s0+s1+s2
-  #includes Sz and Sˆ2 contributions, considers spin-orb=true
-  O_obt = zeros(N, N)
-  idx = 0
-  for i in 1:N
-    for j in 1:i
-      idx += 1
-      O_obt[i, j] += ovec[idx]
-      O_obt[j, i] += ovec[idx]
-    end
-  end
+function hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, N = Int((sqrt(8*length(ovec)+1) - 1)/2), Sz = Sz_builder(N), S2=S2_builder(N))
+	#builds S symmetry shift corresponding to S = s0+s1+s2
+	#includes Sz and Sˆ2 contributions, considers spin-orb=true
+	O_obt = zeros(N, N)
+	idx = 0
+	for i in 1:N
+		for j in 1:i
+			idx += 1
+			O_obt[i,j] += ovec[idx]
+			O_obt[j,i] += ovec[idx]
+		end
+	end
 
-  P_obt = zeros(N, N)
-  idx = 0
-  for i in 1:N
-    for j in 1:i
-      idx += 1
-      P_obt[i, j] += pvec[idx]
-      P_obt[j, i] += pvec[idx]
-    end
-  end
+	P_obt = zeros(N, N)
+	idx = 0
+	for i in 1:N
+		for j in 1:i
+			idx += 1
+			P_obt[i,j] += pvec[idx]
+			P_obt[j,i] += pvec[idx]
+		end
+	end
 
-  s0 = [-tvec[1] * (η^2) - tvec[2] * η - tvec[3] * sz - tvec[4] * (sz^2) - tvec[5] * s2]
+	s0 = [-tvec[1]*(η^2) - tvec[2]*η - tvec[3]*sz - tvec[4]*(sz^2) - tvec[5]*s2]
+	
+	s1 = tvec[2]*collect(Diagonal(ones(N))) - η*O_obt - sz*P_obt - tvec[3]*Sz
 
-  s1 = tvec[2] * collect(Diagonal(ones(N))) - η * O_obt - sz * P_obt - tvec[3] * Sz
+	s2 = zeros(N,N,N,N)
+	for i in 1:N
+		for j in 1:N
+			s2[i,i,j,j] += tvec[1]
+			for k in 1:N
+				s2[i,j,k,k] += 0.5*O_obt[i,j]
+				s2[k,k,i,j] += 0.5*O_obt[i,j]
+				for l in 1:N
+					s2[i,j,k,l] += tvec[4] * Sz[i,j] * Sz[k,l]
+					s2[i,j,k,l] += tvec[5] * S2[i,j,k,l]
+					s2[i,j,k,l] += P_obt[i,j] * Sz[k,l]
+				end
+			end
+		end
+	end
 
-  s2 = zeros(N, N, N, N)
-  for i in 1:N
-    for j in 1:N
-      s2[i, i, j, j] += tvec[1]
-      for k in 1:N
-        s2[i, j, k, k] += 0.5 * O_obt[i, j]
-        s2[k, k, i, j] += 0.5 * O_obt[i, j]
-        for l in 1:N
-          s2[i, j, k, l] += tvec[4] * Sz[i, j] * Sz[k, l]
-          s2[i, j, k, l] += tvec[5] * S2[i, j, k, l]
-          s2[i, j, k, l] += P_obt[i, j] * Sz[k, l]
-        end
-      end
-    end
-  end
-
-  return F_OP((s0, s1, s2), true)
+	return F_OP((s0, s1, s2), true)
 end
 
-function hubbard_bliss_optimizer(F::F_OP, η, sz, s2; verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5")
-  if SAVELOAD
-    fid = h5open(SAVENAME, "cw")
-    if haskey(fid, "BLISS")
-      BLISS_group = fid["BLISS"]
-      if haskey(BLISS_group, "ovec")
-        println("Loading results for BLISS optimization from $SAVENAME")
-        ovec = read(BLISS_group, "ovec")
-        tvec = read(BLISS_group, "tvec")
-        pvec = read(BLISS_group, "pvec")
-        close(fid)
-        S = hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, F.N)
-        close(fid)
-        return F - S
-      end
-    end
-    close(fid)
-  end
+function hubbard_bliss_optimizer(F :: F_OP, η, sz, s2; verbose=true, SAVELOAD = SAVING, SAVENAME=DATAFOLDER*"BLISS.h5")
+	if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		if haskey(fid, "BLISS")
+			BLISS_group = fid["BLISS"]
+			if haskey(BLISS_group, "ovec")
+				println("Loading results for BLISS optimization from $SAVENAME")
+				ovec = read(BLISS_group,"ovec")
+				tvec = read(BLISS_group,"tvec")
+				pvec = read(BLISS_group,"pvec")
+				close(fid)
+				S = hubbard_bliss_sym_params_to_F_OP(ovec, pvec, tvec, η, sz, s2, F.N)
+				close(fid)
+				return F-S
+			end
+		end
+		close(fid)
+	end
 
-  L = Int(F.N * (F.N + 1) / 2)
-  x0 = zeros(2L + 5)
+	L = Int(F.N*(F.N+1)/2)
+	x0 = zeros(2L + 5)
 
-  if F.spin_orb == true
-    n_qubits = F.N
-  else
-    n_qubits = 2 * F.N
-  end
-  Sz = Sz_builder(n_qubits)
-  S2 = S2_builder(n_qubits)
+	if F.spin_orb == true
+		n_qubits = F.N
+	else
+		n_qubits = 2*F.N
+	end
+	Sz = Sz_builder(n_qubits)
+	S2 = S2_builder(n_qubits)
 
 
-  function cost(x)
-    return PAULI_L1(F - hubbard_bliss_sym_params_to_F_OP(x[1:L], x[L+1:2L], x[2L+1:end], η, sz, s2, F.N))
-  end
+	function cost(x)
+		return PAULI_L1(F - hubbard_bliss_sym_params_to_F_OP(x[1:L], x[L+1:2L], x[2L+1:end], η, sz, s2, F.N))
+	end
 
-  if verbose
-    println("Starting 1-norm cost:")
-    @show cost(x0)
-    @time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol=1e-3))
-    println("Final 1-norm cost:")
-    @show sol.minimum
-  else
-    sol = optimize(cost, x0, BFGS())
-  end
+	if verbose
+		println("Starting 1-norm cost:")
+		@show cost(x0)
+		@time sol = optimize(cost, x0, BFGS(), Optim.Options(f_tol = 1e-3))
+		println("Final 1-norm cost:")
+		@show sol.minimum
+	else
+		sol = optimize(cost, x0, BFGS())
+	end
 
-  xsol = sol.minimizer
-  if SAVELOAD
-    fid = h5open(SAVENAME, "cw")
-    create_group(fid, "BLISS")
-    BLISS_group = fid["BLISS"]
-    println("Saving results of BLISS optimization to $SAVENAME")
-    BLISS_group["ovec"] = xsol[1:L]
-    BLISS_group["pvec"] = xsol[L+1:2L]
-    BLISS_group["tvec"] = xsol[2L+1:end]
-    close(fid)
-  end
-  S = hubbard_bliss_sym_params_to_F_OP(xsol[1:L], xsol[L+1:2L], xsol[2L+1:end], η, sz, s2, F.N)
+	xsol = sol.minimizer
+	if SAVELOAD
+		fid = h5open(SAVENAME, "cw")
+		create_group(fid, "BLISS")
+		BLISS_group = fid["BLISS"]
+		println("Saving results of BLISS optimization to $SAVENAME")
+		BLISS_group["ovec"] = xsol[1:L]
+		BLISS_group["pvec"] = xsol[L+1:2L]
+		BLISS_group["tvec"] = xsol[2L+1:end]
+		close(fid)
+	end
+	S = hubbard_bliss_sym_params_to_F_OP(xsol[1:L], xsol[L+1:2L], xsol[2L+1:end], η, sz, s2, F.N)
 
-  return F - S
+	return F - S
 end
 
+function bliss_linprog(F :: F_OP, η; model="highs", verbose=false)
+	if F.spin_orb
+		error("BLISS not defined for spin-orb=true!")
+	end
 
-function symmetrize_O_ij(o_opt, N)
-  idx = 1
-  O = zeros(2, N, N)
-  for s = 1:2
-    for i = 1:N
-      for j = 1:N
-        O[s, i, j] = o_opt[idx]
-        idx += 1
-      end
+    if model == "highs"
+        L1_OPT = Model(HiGHS.Optimizer)
+    elseif model == "ipopt"
+        L1_OPT = Model(Ipopt.Optimizer)
+    else
+        error("Not defined for model = $model")
     end
-  end
-
-
-  O_sym = zeros(2, N, N)
-  for s = 1:2
-    for i = 1:N
-      for j = 1:N
-        O_sym[s, i, j] = (O[s, i, j] + O[s, j, i]) / 2
-      end
-    end
-  end
-
-  return O_sym
-end
-
-
-
-"""
-bliss_linprog(F :: F_OP, η; model='highs', verbose=true,SAVELOAD = SAVING, SAVENAME=DATAFOLDER*'BLISS.h5')
-Shifts the Hamiltonian by a Symmetry operator, leaving unchanged a subspace with a chosen number of electrons η, such that the L1 norm of the resultant Hamiltonian is minimised.
-Optimizes L1-norm through linear programming.
-Solvers: HiGHS and Ipopt (HiGHS is usually faster, both are expected to return identical results)
-Input:
-  The tensors of the input Hamiltonian are assumed to be of the form ``H = E0 + \\sum_{ij} h_{ij} a_i^† a_j + \\sum_{ijkl} g_ijkl a_i^† a_j a_k^† a_l``
-  
-  F::F_OP : (F_OP is defined under src/UTILS/struct.jl)
-  
-    Case 1: F respects spin symmetry, i.e., αα and ββ type components of one-body tensor are identical, and, αααα, ααββ, ββαα and ββββ type components of two body tensor are identical.
-      If N be the number of spatial orbitals, F.mbts[2] (i.e. the one body tensor) is an N * N object, and F.mbts[3] (i.e. the two body tensor) is an 				N*N*N*N object, with indices running over spatial orbitals.
-      
-    Case 2: F may violate spin symmetry, i.e., αα and ββ type components of one-body tensor are not necessarily identical, and αααα, ααββ, ββαα and ββββ type components of two body tensor are not necessarily identical. 
-      If N be the number of spatial orbitals, F.mbts[2] (i.e. the one body tensor) is a 2*N*N object, and F.mbts[3] (i.e. the two body tensor) is a 4*N*N*N*N object. In both one and two body tensors, all indices except the first index run over spatial orbitals. The first index of F.mbts[2] runs over the component types αα and ββ, whereas that of F.mbts[3] runs over the component types αααα, ααββ, ββαα and ββββ. 
-      
-    *NOTE*
-      bliss_linprog() does not work with F_OP where indices run over spin orbitals. Such an input F_OP would result in an incorrect output.
-      One can convert from the F_OP format where indices run over spin-orbitals to the format described under Case 2 using the F_OP_compress(F::F_OP) function. To convert back to the F_OP format where indices run over spin-orbitals, use the F_OP_converter(F::F_OP) function. Both F_OP_compress() and F_OP_converter() functions are defined under src/UTILS/fermionic.jl.
-      
-  η::Int64 : Number of electrons. The subspace corresponding to η electrons is left invariant under BLISS. 
-  model: can be set as 'highs' or 'ipopt'. Set to 'highs' by default.
-  verbose: whether intermediate step calculations are displayed or not
-  SAVELOAD: whether output is saved under SAVED/ folder and whether previously computed results are loaded from savefiles or not. Set to the configuration variable SAVING by dafault.
-  SAVENAME: filename for the savefile of the BLISS results. 
-Output: 
-  Returns the BLISS-treated Hamiltonian F_bliss and the Symmetry shift operator S, where F_bliss = F - S, F being the input F_OP. 
-  The format of the one and two body tensors in the output F_OP objects (i.e. F_bliss and S) are exactly identical to that of their input. 	
-"""
-
-function bliss_linprog(F::F_OP, η; model="highs", verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5", num_threads::Int=1)
-  if F.spin_orb
-    error("BLISS not defined for spin-orb=true!")
-  end
-
-  if model == "highs"
-    L1_OPT = Model(HiGHS.Optimizer)
-  elseif model == "ipopt"
-    L1_OPT = Model(Ipopt.Optimizer)
-  else
-    error("Not defined for model = $model")
-  end
-
-  if num_threads > 1
-    HiGHS.Highs_resetGlobalScheduler(1)
-    set_attribute(L1_OPT, JuMP.MOI.NumberOfThreads(), num_threads)
-  end
-
-  if verbose == false
-    set_silent(L1_OPT)
-  end
-
-  # println("The L1 cost of original Hamiltonian is: ",PAULI_L1(F))
-
-  if size(F.mbts[2], 1) == size(F.mbts[3], 1)
-    if SAVELOAD
-      fid = h5open(SAVENAME, "cw")
-      if haskey(fid, "BLISS")
-        BLISS_group = fid["BLISS"]
-        if haskey(BLISS_group, "ovec")
-          println("Loading results for BLISS optimization from $SAVENAME")
-          ovec = read(BLISS_group, "ovec")
-          t1 = read(BLISS_group, "t1")
-          t2 = read(BLISS_group, "t2")
-          t_opt = [t1, t2]
-          O = zeros(F.N, F.N)
-          idx = 1
-          for i = 1:F.N
-            for j = 1:F.N
-              O[i, j] = ovec[idx]
-              idx += 1
-            end
-          end
-          @show t_opt
-          @show O
-          ham = fid["BLISS_HAM"]
-          F_new = F_OP((read(ham, "h_const"), read(ham, "obt"), read(ham, "tbt")))
-          # println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
-          close(fid)
-          return F_new, F - F_new
-        end
-      end
-      close(fid)
+    
+    
+    if verbose == false
+        set_silent(L1_OPT)
     end
 
-
-    ovec_len = Int(F.N * (F.N + 1) / 2)
+    ovec_len = Int(F.N*(F.N+1)/2)
 
     ν1_len = F.N^2
     ν2_len = F.N^4
-    ν3_len = Int((F.N * (F.N - 1) / 2)^2)
-
+    ν3_len = Int((F.N*(F.N-1)/2)^2)
+    
     @variables(L1_OPT, begin
-      t[1:2]
-      obt[1:ν1_len]
-      tbt1[1:ν2_len]
-      tbt2[1:ν3_len]
-      omat[1:F.N^2]
+        t[1:2]
+        obt[1:ν1_len]
+        tbt1[1:ν2_len]
+        tbt2[1:ν3_len]
+        omat[1:F.N^2]
     end)
 
-    @objective(L1_OPT, Min, sum(obt) + sum(tbt1) + sum(tbt2))
-
+    @objective(L1_OPT, Min, sum(obt)+sum(tbt1)+sum(tbt2))
+    
 
     obt_corr = ob_correction(F)
     #1-body 1-norm
     λ1 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        λ1[idx] = F.mbts[2][i, j] + obt_corr[i, j]
-      end
+    	for j in 1:F.N
+    		idx += 1
+    		λ1[idx] = F.mbts[2][i,j] + obt_corr[i,j]
+    	end
     end
 
     τ_11 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        if i == j
-          τ_11[idx] = F.N
-        end
-      end
+    	for j in 1:F.N
+    		idx += 1
+    		if i == j
+    			τ_11[idx] = 2*F.N
+    		end
+    	end
     end
     τ_12 = zeros(ν1_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        if i == j
-          τ_12[idx] = 1
-        end
-      end
+    	for j in 1:F.N
+    		idx += 1
+    		if i == j
+    			τ_12[idx] = 1
+    		end
+    	end
     end
-    T1 = zeros(ν1_len, ν1_len)
-    T1 += Diagonal((η - F.N) * ones(ν1_len))
+    T1 = zeros(ν1_len,ν1_len)
+    T1 += Diagonal((2η - 2F.N)*ones(ν1_len))
     idx1 = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx1 += 1
-        idx2 = 0
-        for k in 1:F.N
-          for l in 1:F.N
-            idx2 += 1
-            if i == j && k == l
-              T1[idx1, idx2] -= 1
-            end
-          end
-        end
-      end
-    end
-
-
-    @constraint(L1_OPT, low_1, λ1 - τ_11 * t[1] - τ_12 * t[2] + T1 * omat - obt .<= 0)
-    @constraint(L1_OPT, high_1, λ1 - τ_11 * t[1] - τ_12 * t[2] + T1 * omat + obt .>= 0)
-
-    #2-body αβ/βα 1-norm
-    λ2 = zeros(ν2_len)
+    	for j in 1:F.N
+    		idx1 += 1
+    		idx2 = 0
+    		for k in 1:F.N
+    			for l in 1:F.N
+    				idx2 += 1
+    				if i == j && k == l
+ 	   					T1[idx1,idx2] -= 2
+ 	   				end
+ 	   			end
+ 	   		end
+ 	   	end
+ 	end
+ 	
+ 	
+ 	@constraint(L1_OPT, low_1, λ1 - τ_11*t[1] - τ_12*t[2] + T1*omat - obt .<= 0)
+	@constraint(L1_OPT, high_1, λ1 - τ_11*t[1] - τ_12*t[2] + T1*omat + obt .>= 0)
+	
+ 	#2-body αβ/βα 1-norm
+ 	λ2 = zeros(ν2_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:F.N
-          for l in 1:F.N
-            idx += 1
-            λ2[idx] = 0.5 * F.mbts[3][i, j, k, l]
-          end
-        end
-      end
+    	for j in 1:F.N
+    		for k in 1:F.N
+    			for l in 1:F.N
+    				idx += 1
+    				λ2[idx] = 0.5 * F.mbts[3][i,j,k,l]
+    			end
+    		end
+    	end
     end
 
     τ_21 = zeros(ν2_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:F.N
-          for l in 1:F.N
-            idx += 1
-            if i == j && k == l
-              τ_21[idx] = 0.5
-            end
-          end
-        end
-      end
+    	for j in 1:F.N
+    		for k in 1:F.N
+    			for l in 1:F.N
+    				idx += 1
+    				if i == j && k == l
+    					τ_21[idx] = 0.5
+    				end
+    			end
+    		end
+    	end
     end
 
-    T2 = zeros(ν2_len, ν1_len)
+    T2 = zeros(ν2_len,ν1_len)
     idx = 0
     idx_ij = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx_ij += 1
-        idx_kl = 0
-        for k in 1:F.N
-          for l in 1:F.N
-            idx += 1
-            idx_kl += 1
-            if i == j
-              T2[idx, idx_kl] += 0.5
-            end
-            if k == l
-              T2[idx, idx_ij] += 0.5
-            end
-          end
-        end
-      end
+    	for j in 1:F.N
+    		idx_ij += 1
+    		idx_kl = 0
+    		for k in 1:F.N
+    			for l in 1:F.N
+    				idx += 1
+    				idx_kl += 1
+    				if i == j
+    					T2[idx,idx_kl] += 1
+    				end
+    				if k == l
+    					T2[idx,idx_ij] += 1
+    				end
+    			end
+    		end
+    	end
     end
-
-    @constraint(L1_OPT, low_2, λ2 - τ_21 * t[1] - 0.5 * T2 * omat - tbt1 .<= 0)
-    @constraint(L1_OPT, high_2, λ2 - τ_21 * t[1] - 0.5 * T2 * omat + tbt1 .>= 0)
-
-    T_dict = zeros(Int64, F.N, F.N)
+    
+    @constraint(L1_OPT, low_2, λ2 - τ_21*t[1] - 0.5*T2*omat - tbt1 .<= 0)
+    @constraint(L1_OPT, high_2, λ2 - τ_21*t[1] - 0.5*T2*omat + tbt1 .>= 0)
+    
+    T_dict = zeros(Int64,F.N,F.N)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        T_dict[i, j] = idx
-      end
+    	for j in 1:F.N
+    		idx += 1
+    		T_dict[i,j] = idx
+    	end
     end
     #2-body αα/ββ 1-norm
     λ3 = zeros(ν3_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in 1:j-1
-            idx += 1
-            λ3[idx] = F.mbts[3][i, j, k, l] - F.mbts[3][i, l, k, j]
-          end
-        end
-      end
+    	for j in 1:F.N
+    		for k in 1:i-1
+    			for l in 1:j-1
+    				idx += 1
+    				λ3[idx] = F.mbts[3][i,j,k,l] - F.mbts[3][i,l,k,j]
+    			end
+    		end
+    	end
     end
-
+    
     τ_31 = zeros(ν3_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in 1:j-1
-            idx += 1
-            if i == j && k == l
-              τ_31[idx] += 1
-            end
-            if i == l && k == j
-              τ_31[idx] -= 1
-            end
-          end
-        end
-      end
+    	for j in 1:F.N
+    		for k in 1:i-1
+    			for l in 1:j-1
+    				idx += 1
+    				if i == j && k == l
+    					τ_31[idx] += 1
+    				end
+    				if i == l && k == j
+    					τ_31[idx] -= 1
+    				end
+    			end
+    		end
+    	end
     end
+    
+    
 
-
-
-    T3 = zeros(ν3_len, ν1_len)
+    T3 = zeros(ν3_len,ν1_len)
     idx = 0
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in 1:j-1
-            idx += 1
+    	for j in 1:F.N
+    		for k in 1:i-1
+    			for l in 1:j-1
+    				idx += 1
+    				
+    				idx_ij = T_dict[i,j]
+    				if k == l
+    					T3[idx,idx_ij] += 1
+    				end
+    				
+    				idx_kl = T_dict[k,l]
+    				if i == j
+    					T3[idx,idx_kl] += 1
+    				end
 
-            idx_ij = T_dict[i, j]
-            if k == l
-              T3[idx, idx_ij] += 0.5
-            end
+    				idx_il = T_dict[i,l]
+    				if k == j
+    					T3[idx,idx_il] -= 1
+    				end
 
-            idx_kl = T_dict[k, l]
-            if i == j
-              T3[idx, idx_kl] += 0.5
-            end
-
-            idx_il = T_dict[i, l]
-            if k == j
-              T3[idx, idx_il] -= 0.5
-            end
-
-            idx_kj = T_dict[k, j]
-            if i == l
-              T3[idx, idx_kj] -= 0.5
-            end
-          end
-        end
-      end
+    				idx_kj = T_dict[k,j]
+    				if i == l
+    					T3[idx,idx_kj] -= 1
+    				end
+    			end
+    		end
+    	end
     end
-
-    @constraint(L1_OPT, low_3, λ3 - τ_31 * t[1] - T3 * omat - tbt2 .<= 0)
-    @constraint(L1_OPT, high_3, λ3 - τ_31 * t[1] - T3 * omat + tbt2 .>= 0)
-
-    JuMP.optimize!(L1_OPT)
-
+   
+    @constraint(L1_OPT, low_3, λ3 - τ_31*t[1] - T3*omat - tbt2 .<= 0)
+    @constraint(L1_OPT, high_3, λ3 - τ_31*t[1] - T3*omat + tbt2 .>= 0)
+    
+    optimize!(L1_OPT)
+    
     t_opt = value.(t)
     o_opt = value.(omat)
-    @show t_opt
-    idx = 1
-    O = zeros(F.N, F.N)
-    for i = 1:F.N
-      for j = 1:F.N
-        O[i, j] = o_opt[idx]
-        idx += 1
-      end
+    
+    idx=1
+    O=zeros(F.N,F.N)
+    for i=1:F.N
+    	for j=1:F.N
+    		O[i,j]=o_opt[idx]
+    		idx+=1
+    	end
     end
-    @show O
-    O = (O + O') / 2
-
-
-    Ne, Ne2 = symmetry_builder(F)
-
-
-
+    O=(O+O')/2	
+        
+        
+    Ne,Ne2 = symmetry_builder(F)
+    
+    
+    
     s2_tbt = t_opt[1] * Ne2.mbts[3]
     for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:F.N
-          s2_tbt[i, j, k, k] += O[i, j]
-          s2_tbt[k, k, i, j] += O[i, j]
-        end
-      end
+    	for j in 1:F.N
+    		for k in 1:F.N
+    			s2_tbt[i,j,k,k] += O[i,j]
+    			s2_tbt[k,k,i,j] += O[i,j]
+    		end
+    	end
     end
-    s2 = F_OP(([0], [0], s2_tbt))
+    s2 = F_OP(([0],[0],s2_tbt))
 
-    s1_obt = t_opt[2] * Ne.mbts[2] - 2η * O
-    s1 = F_OP(([-t_opt[2] * η - t_opt[1] * η^2], s1_obt))
-    # s1 = F_OP(([-t_opt[2] * η], s1_obt))
-
+    s1_obt = t_opt[2]*Ne.mbts[2] - 2η*O
+    s1 = F_OP(([0],s1_obt))
+    
     F_new = F - s1 - s2
-    # F_new = F - s1
-    println("h_const after BLISS:", F_new.mbts[1])
-    if SAVELOAD
-      fid = h5open(SAVENAME, "cw")
-      create_group(fid, "BLISS")
-      BLISS_group = fid["BLISS"]
-      println("Saving results of BLISS optimization to $SAVENAME")
-      BLISS_group["ovec"] = o_opt
-      BLISS_group["t1"] = t_opt[1]
-      BLISS_group["t2"] = t_opt[2]
-      BLISS_group["t3"] = 0
-      BLISS_group["N"] = F.N
-      BLISS_group["Ne"] = η
-      create_group(fid, "BLISS_HAM")
-      MOL_DATA = fid["BLISS_HAM"]
-      MOL_DATA["h_const"] = F_new.mbts[1]
-      MOL_DATA["obt"] = F_new.mbts[2]
-      MOL_DATA["tbt"] = F_new.mbts[3]
-      MOL_DATA["threebt"] = 0
-      MOL_DATA["eta"] = η
-      close(fid)
+    if verbose == true
+    	println("Finished BLISS optimization, L1 cost reduced from $(PAULI_L1(F)) to $(PAULI_L1(F_new))")
     end
-
-    #println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
-    return F_new, s1 + s2
-  else
-
-    if SAVELOAD
-      fid = h5open(SAVENAME, "cw")
-      if haskey(fid, "BLISS")
-        BLISS_group = fid["BLISS"]
-        if haskey(BLISS_group, "ovec")
-          println("Loading results for BLISS optimization from $SAVENAME")
-          ovec = read(BLISS_group, "ovec")
-          t1 = read(BLISS_group, "t1")
-          t2 = read(BLISS_group, "t2")
-          t_opt = [t1, t2]
-          O = symmetrize_O_ij(ovec, F.N)
-          @show t_opt
-          @show O
-          ham = fid["BLISS_HAM"]
-          F_new = F_OP((read(ham, "h_const"), read(ham, "obt"), read(ham, "tbt")))
-          #println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
-          close(fid)
-          return F_new, F - F_new
-        end
-      end
-      close(fid)
-    end
-
-    ovec_len = Int(F.N * (F.N + 1) / 2)
-
-
-    # The dimension for each vector that we are optimizing
-    v1_len = 2 * F.N^2
-    ν2_len = 2 * F.N^4
-    ν3_len = Int(2 * (F.N * (F.N - 1) / 2)^2)
-    v4_len = 2 * (F.N^2 * (F.N - 1) * (F.N - 2))
-    v5_len = 2 * (F.N * (F.N - 1) * (F.N - 2))^2
-
-    # Initializing the variables to be optimized
-    @variables(L1_OPT, begin
-      t[1:3]
-
-      obt[1:v1_len]
-      tbt1[1:ν2_len]
-      tbt2[1:ν3_len]
-      tbt3[1:v4_len]
-      tbt4[1:v4_len]
-      threebt[1:v5_len]
-      omat[1:2*F.N^2]
-    end)
-
-    @objective(L1_OPT, Min, 0.5 * (sum(obt) + sum(tbt1) + sum(tbt2)))
-
-    # One-body correction from the two-body term g
-    obt_corr = ob_correction(F)
-    # One-body correction from the three-body term t
-    obt_three_corr = ob_correction_3bd(F)
-
-    # Original one-body tensors without tilde
-    λ1 = zeros(2 * F.N^2)
-    idx = 0
-    for s in 1:2
-      for i in 1:F.N
-        for j in 1:F.N
-          idx += 1
-          λ1[idx] = F.mbts[2][s, i, j] + obt_corr[s, i, j] + obt_three_corr[s, i, j]
-        end
-      end
-    end
-
-    # Shift due to (Ne - ne) term
-    τ_11 = zeros(v1_len)
-    idx = 0
-    for s in 1:2
-      for i in 1:F.N
-        for j in 1:F.N
-          idx += 1
-          if i == j
-            τ_11[idx] = 1
-          end
-        end
-      end
-    end
-
-    # Shift due to (Ne^2 - ne^2) term
-    τ_12 = zeros(2 * F.N^2)
-    idx = 0
-    for s in 1:2
-      for i in 1:F.N
-        for j in 1:F.N
-          idx += 1
-          if i == j
-            τ_12[idx] = 2 * F.N
-          end
-        end
-      end
-    end
-
-    # Shift due to (Ne^3 - ne^3) term
-
-    τ_13 = zeros(2 * F.N^2)
-    idx = 0
-    for s in 1:2
-      for i in 1:F.N
-        for j in 1:F.N
-          idx += 1
-          if i == j
-            τ_13[idx] = 1
-          end
-        end
-      end
-    end
-    T1 = zeros(2 * F.N^2, 2 * F.N^2)
-    T1 += Diagonal((2η - 2F.N) * ones(2 * F.N^2))
-    idx1 = 0
-    for s in 1:2
-      for i in 1:F.N
-        for j in 1:F.N
-          idx1 += 1
-          idx2 = 0
-          for q in 1:2
-            for k in 1:F.N
-              for l in 1:F.N
-                idx2 += 1
-                if i == j && k == l
-                  T1[idx1, idx2] -= 2
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-
-
-    @constraint(L1_OPT, low_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - t_13 * t[3] + (2η - 4 * F.N) * omat - obt .<= 0)
-    @constraint(L1_OPT, high_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - t_13 * t[3] + (2η - 4 * F.N) * omat + obt .>= 0)
-
-    tbt_corr_1 = tb_correction_1(F)
-
-    λ2 = zeros(ν2_len)
-    idx = 0
-    for s in 2:3
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:F.N
-            for l in 1:F.N
-              idx += 1
-              λ2[idx] = 0.5 * F.mbts[3][s, i, j, k, l] + 0.5 * tbt_corr_1[s, i, j, k, l]
-            end
-          end
-        end
-      end
-    end
-
-    τ_21 = zeros(ν2_len)
-    idx = 0
-    for s in 2:3
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:F.N
-            for l in 1:F.N
-              idx += 1
-              if i == j && k == l
-                τ_21[idx] = 0.5
-              end
-            end
-          end
-        end
-      end
-    end
-
-    T2 = zeros(Int64, Int64(ν2_len / 2), F.N^2)
-    idx = 0
-    idx_ij = 0
-
-    for i in 1:F.N
-      for j in 1:F.N
-        idx_ij += 1
-
-
-        for k in 1:F.N
-          for l in 1:F.N
-            idx += 1
-
-            if k == l
-              T2[idx, idx_ij] += 1
-            end
-          end
-        end
-
-      end
-    end
-
-
-    @constraint(L1_OPT, low_2, λ2 - τ_21 * t[1] - vcat(T2 * omat[1:F.N^2], T2 * omat[F.N^2+1:end]) - tbt1 .<= 0)
-    @constraint(L1_OPT, high_2, λ2 - τ_21 * t[1] - vcat(T2 * omat[1:F.N^2], T2 * omat[F.N^2+1:end]) + tbt1 .>= 0)
-
-    tbt_corr_2 = tb_correction_2(F)
-
-    T_dict = zeros(Int64, F.N, F.N)
-    idx = 0
-    for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        T_dict[i, j] = idx
-      end
-    end
-    #2-body αα/ββ 1-norm
-    λ3 = zeros(ν3_len)
-    idx = 0
-    arr_align = [1, 4]
-    arr_anti = [2, 3]
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:i-1
-            for l in j+1:F.N
-              idx += 1
-              λ3[idx] = F.mbts[3][s, i, j, k, l] - F.mbts[3][s, i, l, k, j] + tbt_corr_2[s, i, j, k, l] - tbt_corr_2[s, i, l, k, j]
-            end
-          end
-        end
-      end
-    end
-
-    τ_31 = zeros(ν3_len)
-    idx = 0
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:i-1
-            for l in j+1:F.N
-              idx += 1
-
-              if i == l && k == j
-                τ_31[idx] += 1
-              end
-            end
-          end
-        end
-      end
-    end
-
-
-
-    T3 = zeros(Int64(ν3_len / 2), F.N^2)
-    idx = 0
-
-    for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in j+1:F.N
-            idx += 1
-
-            idx_ij = T_dict[i, j]
-            if k == l
-              T3[idx, idx_ij] += 2
-            end
-
-
-            idx_il = T_dict[i, l]
-            if k == j
-              T3[idx, idx_il] -= 2
-            end
-
-
-          end
-        end
-      end
-    end
-
-    @constraint(L1_OPT, low_3, λ3 + τ_31 * t[1] - vcat(T3 * omat[1:F.N^2], T3 * omat[F.N^2+1:end]) - tbt2 .<= 0)
-    @constraint(L1_OPT, high_3, λ3 + τ_31 * t[1] - vcat(T3 * omat[1:F.N^2], T3 * omat[F.N^2+1:end]) + tbt2 .>= 0)
-
-    # New tbt constraint
-    tbt_corr_2 = tb_correction_2(F)
-
-    T_dict = zeros(Int64, F.N, F.N)
-    idx = 0
-    for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        T_dict[i, j] = idx
-      end
-    end
-    λ4 = zeros(ν4_len)
-    idx = 0
-    arr_align = [1, 4]
-    arr_anti = [2, 3]
-    for s in arr_align
-      for i in 1:F.N
-        for k in 1:F.N
-          for m in 1:i-1
-            for j in j+1:F.N
-              idx += 1
-              λ4[idx] = 1 / 8 * (sum(F.mbts[4][s, i, l, k, j, m, l] + F.mbts[4][s, i, l, k, l, m, j] + F.mbts[4][s, i, j, k, l, m, l] for l in 1:F.N) + F.mbts[4][s, i, j, k, j, m, j])
-            end
-          end
-        end
-      end
-    end
-
-    τ_41 = zeros(v4_len)
-    idx = 0
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:i-1
-            for l in j+1:F.N
-              idx += 1
-
-              if i == j && k == l
-                τ_41[idx] += 1
-              end
-            end
-          end
-        end
-      end
-    end
-
-    τ_42 = zeros(v4_len)
-    idx = 0
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:i-1
-            for l in j+1:F.N
-              idx += 1
-
-              if i == j && k == l
-                τ_42[idx] += 3
-              end
-            end
-          end
-        end
-      end
-    end
-
-
-
-    T4 = zeros(Int64(ν3_len / 2), F.N^2)
-    idx = 0
-
-    for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in j+1:F.N
-            idx += 1
-
-            idx_ij = T_dict[i, j]
-            if k == l
-              T4[idx, idx_ij] += 2
-            end
-
-
-            idx_il = T_dict[i, l]
-            if k == j
-              T4[idx, idx_il] -= 2
-            end
-
-
-          end
-        end
-      end
-    end
-
-    @constraint(L1_OPT, low_4, λ4 + τ_41 * t[1] + τ_42 * t[3] - vcat(T4 * omat[1:F.N^2], T4 * omat[F.N^2+1:end]) - tbt3 .<= 0)
-    @constraint(L1_OPT, high_4, λ4 + τ_41 * t[1] + τ_42 * t[3] - vcat(T4 * omat[1:F.N^2], T4 * omat[F.N^2+1:end]) + tbt3 .>= 0)
-
-    # New tbt constraint 2
-    tbt_corr_2 = tb_correction_2(F)
-
-    T_dict = zeros(Int64, F.N, F.N)
-    idx = 0
-    for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        T_dict[i, j] = idx
-      end
-    end
-    λ5 = zeros(ν4_len)
-    idx = 0
-    arr_align = [1, 4]
-    arr_anti = [2, 3]
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for l in 1:i-1
-            for n in j+1:F.N
-              idx += 1
-              λ5[idx] = 1 / 8 * (sum(-F.mbts[4][s, k, j, i, l, k, n] + F.mbts[4][s, k, j, k, l, i, n] + F.mbts[4][s, i, j, k, l, k, n] for k in 1:F.N) + F.mbts[4][s, i, j, i, l, i, n])
-            end
-          end
-        end
-      end
-    end
-
-    τ_51 = zeros(v4_len)
-    idx = 0
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:i-1
-            for l in j+1:F.N
-              idx += 1
-
-              if i == l && k == j
-                τ_51[idx] += 1
-              end
-            end
-          end
-        end
-      end
-    end
-
-
-
-    T5 = zeros(Int64(ν3_len / 2), F.N^2)
-    idx = 0
-
-    for i in 1:F.N
-      for j in 1:F.N
-        for k in 1:i-1
-          for l in j+1:F.N
-            idx += 1
-
-            idx_ij = T_dict[i, j]
-            if k == l
-              T5[idx, idx_ij] += 2
-            end
-
-
-            idx_il = T_dict[i, l]
-            if k == j
-              T5[idx, idx_il] -= 2
-            end
-
-
-          end
-        end
-      end
-    end
-
-    @constraint(L1_OPT, low_5, λ5 + τ_51 * t[1] - vcat(T5 * omat[1:F.N^2], T5 * omat[F.N^2+1:end]) - tbt4 .<= 0)
-    @constraint(L1_OPT, high_5, λ5 + τ_51 * t[1] - vcat(T5 * omat[1:F.N^2], T5 * omat[F.N^2+1:end]) + tbt4 .>= 0)
-
-    # Three body constraint
-    tbt_corr_2 = tb_correction_2(F)
-
-    T_dict = zeros(Int64, F.N, F.N)
-    idx = 0
-    for i in 1:F.N
-      for j in 1:F.N
-        idx += 1
-        T_dict[i, j] = idx
-      end
-    end
-    λ6 = zeros(v5_len)
-    idx = 0
-    arr_align = [1, 4]
-    arr_anti = [2, 3]
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:F.N
-            for l in 1:F.N
-              for m in 1:F.N
-                for n in 1:F.N
-                  if i != k && i != m && k != m && j != l && l != n && j != n
-                    idx += 1
-                    λ6[idx] = 1 / 8 * F.mbts[4][i, j, k, l, m, n]
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-
-    τ_61 = zeros(v5_len)
-    idx = 0
-    for s in arr_align
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:F.N
-            for l in 1:F.N
-              for m in 1:F.N
-                for n in 1:F.N
-                  idx += 1
-                  if i == j && k == l && m == n
-                    τ_61[idx] += 1
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-
-
-    @constraint(L1_OPT, low_6, λ6 + τ_61 * t[3] - threebt .<= 0)
-    @constraint(L1_OPT, high_6, λ6 + τ_61 * t[3] + threebt .>= 0)
-
-
-
-    JuMP.optimize!(L1_OPT)
-
-
-    t_opt = value.(t)
-    o_opt = value.(omat)
-    #@show t_opt
-
-
-    idx = 1
-    O = zeros(2, F.N, F.N)
-    for s = 1:2
-      for i = 1:F.N
-        for j = 1:F.N
-          O[s, i, j] = o_opt[idx]
-          idx += 1
-        end
-      end
-    end
-
-
-    O_sym = zeros(2, F.N, F.N)
-    for s = 1:2
-      for i = 1:F.N
-        for j = 1:F.N
-          O_sym[s, i, j] = (O[s, i, j] + O[s, j, i]) / 2
-        end
-      end
-    end
-
-    O = O_sym
-    #@show O
-
-
-    Ne, Ne2 = symmetry_builder(F)
-
-
-    s2_tbt = zeros(4, F.N, F.N, F.N, F.N)
-    for i = 1:4
-      s2_tbt[i, :, :, :, :] = t_opt[1] * Ne2.mbts[3]
-    end
-    #=for sigma in arr_align
-      for i in 1:F.N
-      	for j in 1:F.N
-      		for k in 1:F.N
-      			for l in 1:F.N
-      			#s2_tbt[sigma,i,j,k,k] += 2*O[div(sigma-1,2)+1,i,j]
-       			if k==l
-       				s2_tbt[sigma,i,j,k,l] += O[div(sigma-1,2)+1,i,j]
-       			end
-       			if i==j
-       				s2_tbt[sigma,k,l,i,j] += O[div(sigma-1,2)+1,k,l]
-       			end
-       		end
-      		end
-      	end
-      end
-     end
-
-     for sigma in arr_anti
-      for i in 1:F.N
-      	for j in 1:F.N
-      		for k in 1:F.N
-      			for l in 1:F.N
-      			#s2_tbt[sigma,i,j,k,k] += 2*O[div(sigma-1,2)+1,i,j]
-       			if k==l
-       				s2_tbt[sigma,i,j,k,l] += O[sigma-1,i,j]
-       			end
-       			if i==j
-       				s2_tbt[5-sigma,k,l,i,j] += O[4-sigma,k,l]
-       			end
-       		end
-      		end
-      	end
-      end
-     end=#
-
-    for sigma = 1:4
-      for i in 1:F.N
-        for j in 1:F.N
-          for k in 1:F.N
-            s2_tbt[sigma, i, j, k, k] += 2 * O[div(sigma - 1, 2)+1, i, j]
-            #s2_tbt[sigma,k,k,i,j] += O[div(sigma-1,2)+1,i,j]
-
-          end
-        end
-      end
-    end
-
-    s1_obt = zeros(2, F.N, F.N)
-    for i = 1:2
-      s1_obt[i, :, :] = t_opt[2] * Ne.mbts[2] .- 2η * O[i, :, :]
-    end
-
-    s = F_OP(([-t_opt[2] * η - t_opt[1] * η^2], s1_obt, s2_tbt))
-    #@show s
-    F_new = F - s
-
-
-    if SAVELOAD
-      fid = h5open(SAVENAME, "cw")
-      create_group(fid, "BLISS")
-      BLISS_group = fid["BLISS"]
-      println("Saving results of BLISS optimization to $SAVENAME")
-      BLISS_group["ovec"] = o_opt
-      BLISS_group["t1"] = t_opt[1]
-      BLISS_group["t2"] = t_opt[2]
-      create_group(fid, "BLISS_HAM")
-      MOL_DATA = fid["BLISS_HAM"]
-      MOL_DATA["h_const"] = F_new.mbts[1]
-      MOL_DATA["obt"] = F_new.mbts[2]
-      MOL_DATA["tbt"] = F_new.mbts[3]
-      MOL_DATA["eta"] = η
-      close(fid)
-    end
-
-
-    println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
-    return F_new, s
-
-  end
-
+    
+    return F_new, s1+s2
 end
 

--- a/src/UTILS/bliss_extension.jl
+++ b/src/UTILS/bliss_extension.jl
@@ -1,0 +1,529 @@
+"""
+We assume size(F.mbts[2], 1) == size(F.mbts[3], 1)
+"""
+function bliss_linprog_extension(F::F_OP, η; model="highs", verbose=true, SAVELOAD=SAVING, SAVENAME=DATAFOLDER * "BLISS.h5", num_threads::Int=1)
+  if F.spin_orb
+    error("BLISS not defined for spin-orb=true!")
+  end
+
+  if model == "highs"
+    L1_OPT = Model(HiGHS.Optimizer)
+  elseif model == "ipopt"
+    L1_OPT = Model(Ipopt.Optimizer)
+  else
+    error("Not defined for model = $model")
+  end
+
+  if num_threads > 1
+    HiGHS.Highs_resetGlobalScheduler(1)
+    set_attribute(L1_OPT, JuMP.MOI.NumberOfThreads(), num_threads)
+  end
+
+  if verbose == false
+    set_silent(L1_OPT)
+  end
+
+  ### Saving part begins ###
+
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    if haskey(fid, "BLISS")
+      BLISS_group = fid["BLISS"]
+      if haskey(BLISS_group, "ovec")
+        println("Loading results for BLISS optimization from $SAVENAME")
+        ovec = read(BLISS_group, "ovec")
+        t1 = read(BLISS_group, "t1")
+        t2 = read(BLISS_group, "t2")
+        t3 = read(BLISS_group, "t3")
+        t_opt = [t1, t2, t3]
+        O = zeros(F.N, F.N)
+        idx = 1
+        for i = 1:F.N
+          for j = 1:F.N
+            O[i, j] = ovec[idx]
+            idx += 1
+          end
+        end
+        @show t_opt
+        @show O
+        ham = fid["BLISS_HAM"]
+        F_new = F_OP((read(ham, "h_const"), read(ham, "obt"), read(ham, "tbt"), read(ham, "threebt")))
+        # println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+        close(fid)
+        return F_new, F - F_new
+      end
+    end
+    close(fid)
+  end
+
+  ### Saving part ends ###
+
+
+  ovec_len = Int(F.N * (F.N + 1) / 2)
+
+  ν1_len = F.N^2
+  ν2_len = F.N^4
+  ν3_len = Int((F.N * (F.N - 1) / 2)^2)
+  v4_len = F.N^2 * (F.N - 1) * (F.N - 2)
+
+  v6_len = (F.N * (F.N - 1) * (F.N - 2))^2
+
+  @variables(L1_OPT, begin
+    t[1:3]
+    obt[1:ν1_len]
+    tbt1[1:ν2_len]
+    tbt2[1:ν3_len]
+    tbt3[1:v4_len]
+    tbt4[1:v4_len]
+    threebt[1:v6_len]
+    omat[1:F.N^2]
+  end)
+
+  @objective(L1_OPT, Min, sum(obt) + sum(tbt1) + sum(tbt2) + sum(tbt3) + sum(tbt4) + sum(threebt))
+
+  ### Constraint ###
+  obt_corr = ob_correction(F)
+  # h_ij + 2\sum_k g_ijkk 
+  λ1 = zeros(ν1_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx += 1
+      λ1[idx] = F.mbts[2][i, j] + obt_corr[i, j] + ob_correction_3bd_1(F, i, j) + ob_correction_3bd_2(F, i, j) + ob_correction_3bd_3(F, i, j) + ob_correction_3bd_4(F, i, j)
+    end
+  end
+
+  # \mu_1\delta_ij t[1] corresponds to \mu_1
+  τ_11 = zeros(ν1_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx += 1
+      if i == j
+        τ_11[idx] = 1
+      end
+    end
+  end
+
+  # 2N \mu_2\delta_ij t[2] corresponds to \mu_2
+  τ_12 = zeros(ν1_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx += 1
+      if i == j
+        τ_12[idx] = 2 * F.N
+      end
+    end
+  end
+
+  τ_13 = zeros(ν1_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx += 1
+      if i == j
+        τ_13[idx] = 1 / 8 * (3 * F.N + 3) + 3 / 2 * F.N^2
+      end
+    end
+  end
+
+  # \xi part omat corresponds to \xi
+  T1 = zeros(ν1_len, ν1_len)
+  T1 += Diagonal((η - F.N) * ones(ν1_len))
+  idx1 = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx1 += 1
+      idx2 = 0
+      for k in 1:F.N
+        for l in 1:F.N
+          idx2 += 1
+          if i == j && k == l
+            T1[idx1, idx2] -= 1
+          end
+        end
+      end
+    end
+  end
+
+
+  @constraint(L1_OPT, low_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - τ_13 * t[3] + T1 * omat - obt .<= 0)
+  @constraint(L1_OPT, high_1, λ1 - τ_11 * t[1] - τ_12 * t[2] - τ_13 * t[3] + T1 * omat + obt .>= 0)
+
+  # This is the 1/2 g_ijkl part
+  tbt_corr_1 = tb_correction_1(F)
+  λ2 = zeros(ν2_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        for l in 1:F.N
+          idx += 1
+          λ2[idx] = 0.5 * F.mbts[3][i, j, k, l] + 0.5 * tbt_corr_1[i, j, k, l]
+        end
+      end
+    end
+  end
+
+  # this is the \mu_2\delta_ij\delta_kl part
+  τ_21 = zeros(ν2_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        for l in 1:F.N
+          idx += 1
+          if i == j && k == l
+            τ_21[idx] = 0.5
+          end
+        end
+      end
+    end
+  end
+
+  # this is the \mu_2\delta_ij\delta_kl part
+  τ_22 = zeros(ν2_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        for l in 1:F.N
+          idx += 1
+          if i == j && k == l
+            τ_22[idx] = 1.5 * F.N
+          end
+        end
+      end
+    end
+  end
+
+  # This is the 1/2 (\xi_ij\delta_kl + \delta_ij\xi_kl) part
+  T2 = zeros(ν2_len, ν1_len)
+  idx = 0
+  idx_ij = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx_ij += 1
+      idx_kl = 0
+      for k in 1:F.N
+        for l in 1:F.N
+          idx += 1
+          idx_kl += 1
+          if i == j
+            T2[idx, idx_kl] += 0.5
+          end
+          if k == l
+            T2[idx, idx_ij] += 0.5
+          end
+        end
+      end
+    end
+  end
+
+  @constraint(L1_OPT, low_2, λ2 - τ_21 * t[2] - τ_22 * t[3] - 0.5 * T2 * omat - tbt1 .<= 0)
+  @constraint(L1_OPT, high_2, λ2 - τ_21 * t[2] - τ_22 * t[3] - 0.5 * T2 * omat + tbt1 .>= 0)
+
+  T_dict = zeros(Int64, F.N, F.N)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      idx += 1
+      T_dict[i, j] = idx
+    end
+  end
+
+  tbt_corr_2 = tb_correction_2(F)
+  # g_ijkl - g_ilkj
+  λ3 = zeros(ν3_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:i-1
+        for l in 1:j-1
+          idx += 1
+          λ3[idx] = F.mbts[3][i, j, k, l] - F.mbts[3][i, l, k, j] + tbt_corr_2[i, j, k, l] - tbt_corr_2[i, l, k, j]
+        end
+      end
+    end
+  end
+
+  # \mu_2(\delta_ij\delta_kl - \delta_il\delta_kj)
+  τ_31 = zeros(ν3_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:i-1
+        for l in 1:j-1
+          idx += 1
+          if i == j && k == l
+            τ_31[idx] += 1
+          end
+          if i == l && k == j
+            τ_31[idx] -= 1
+          end
+        end
+      end
+    end
+  end
+
+  τ_32 = zeros(ν3_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:i-1
+        for l in 1:j-1
+          idx += 1
+          if i == j && k == l
+            τ_32[idx] += 3 * F.N
+          end
+          if i == l && k == j
+            τ_32[idx] -= 3 * F.N
+          end
+        end
+      end
+    end
+  end
+
+
+
+  T3 = zeros(ν3_len, ν1_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:i-1
+        for l in 1:j-1
+          idx += 1
+
+          idx_ij = T_dict[i, j]
+          if k == l
+            T3[idx, idx_ij] += 0.5
+          end
+
+          idx_kl = T_dict[k, l]
+          if i == j
+            T3[idx, idx_kl] += 0.5
+          end
+
+          idx_il = T_dict[i, l]
+          if k == j
+            T3[idx, idx_il] -= 0.5
+          end
+
+          idx_kj = T_dict[k, j]
+          if i == l
+            T3[idx, idx_kj] -= 0.5
+          end
+        end
+      end
+    end
+  end
+
+  @constraint(L1_OPT, low_3, λ3 - τ_31 * t[2] - τ_32 * t[3] - T3 * omat - tbt2 .<= 0)
+  @constraint(L1_OPT, high_3, λ3 - τ_31 * t[2] - τ_32 * t[3] - T3 * omat + tbt2 .>= 0)
+
+  λ4 = zeros(v4_len)
+  idx = 0
+  for i in 1:F.N
+    for k in 1:F.N
+      for m in 1:F.N
+        for j in 1:F.N
+          if i != k && k != m && i != m
+            idx += 1
+            λ4[idx] += 1 / 8 * (sum(F.mbts[4][i, l, k, j, m, l] for l in 1:F.N) + sum(F.mbts[4][i, l, k, l, m, j] for l in 1:F.N) + sum(F.mbts[4][i, j, k, l, m, l] for l in 1:F.N))
+            λ4[idx] += 1 / 8 * F.mbts[4][i, j, k, j, m, j]
+          end
+        end
+      end
+    end
+  end
+
+  τ_41 = zeros(v4_len)
+  idx = 0
+  for i in 1:F.N
+    for k in 1:F.N
+      for m in 1:F.N
+        for j in 1:F.N
+          if i != k && k != m && i != m
+            idx += 1
+            if k == j
+              τ_41[idx] += 1
+            end
+            if m == j
+              τ_41[idx] += 1
+            end
+            if i == j
+              τ_41[idx] += 1
+            end
+            if i == j && k == j && m == j
+              τ_41[idx] -= 1
+            end
+          end
+        end
+      end
+    end
+  end
+
+
+
+  @constraint(L1_OPT, low_4, λ4 - 1 / 8 * τ_41 * t[3] - tbt3 .<= 0)
+  @constraint(L1_OPT, high_4, λ4 - 1 / 8 * τ_41 * t[3] + tbt3 .>= 0)
+
+  λ5 = zeros(v4_len)
+  idx = 0
+  for j in 1:F.N
+    for l in 1:F.N
+      for n in 1:F.N
+        for i in 1:F.N
+          if j != l && l != n && j != n
+            idx += 1
+            λ5[idx] += 1 / 8 * (-sum(F.mbts[4][k, j, i, l, k, n] for k in 1:F.N) + sum(F.mbts[4][k, j, k, l, i, n] for k in 1:F.N) + sum(F.mbts[4][i, j, k, l, k, n] for k in 1:F.N))
+            λ5[idx] += 1 / 8 * F.mbts[4][i, j, i, l, i, n]
+          end
+        end
+      end
+    end
+  end
+
+  τ_51 = zeros(v4_len)
+  idx = 0
+  for j in 1:F.N
+    for l in 1:F.N
+      for n in 1:F.N
+        for i in 1:F.N
+          if j != l && l != n && j != n
+            idx += 1
+            if l == i
+              τ_51[idx] += 1
+            end
+            if n == i
+              τ_51[idx] += 1
+            end
+            if j == i
+              τ_51[idx] += 1
+            end
+            if j == i && l == i && n == i
+              τ_51[idx] -= 1
+            end
+          end
+        end
+      end
+    end
+  end
+
+
+
+  @constraint(L1_OPT, low_5, λ5 - 1 / 8 * τ_51 * t[3] - tbt4 .<= 0)
+  @constraint(L1_OPT, high_5, λ5 - 1 / 8 * τ_51 * t[3] + tbt4 .>= 0)
+
+
+
+
+  λ6 = zeros(v6_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        for l in 1:F.N
+          for m in 1:F.N
+            for n in 1:F.N
+              if i != k && k != m && i != m && j != l && l != n && j != n
+                idx += 1
+                λ6[idx] = 1 / 8 * F.mbts[4][i, j, k, l, m, n]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  τ_61 = zeros(v6_len)
+  idx = 0
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        for l in 1:F.N
+          for m in 1:F.N
+            for n in 1:F.N
+              if i != k && k != m && i != m && j != l && l != n && j != n
+                idx += 1
+                if i == j && k == l && m == n
+                  τ_61[idx] = 1 / 8
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  @constraint(L1_OPT, low_6, λ6 - τ_61 * t[3] - threebt .<= 0)
+  @constraint(L1_OPT, high_6, λ6 - τ_61 * t[3] + threebt .>= 0)
+
+
+  JuMP.optimize!(L1_OPT)
+
+  t_opt = value.(t)
+  o_opt = value.(omat)
+  @show t_opt
+  idx = 1
+  O = zeros(F.N, F.N)
+  for i = 1:F.N
+    for j = 1:F.N
+      O[i, j] = o_opt[idx]
+      idx += 1
+    end
+  end
+  @show O
+  O = (O + O') / 2
+
+
+  Ne, Ne2, Ne3 = symmetry_builder_extension(F)
+
+
+  s_threebt = t_opt[3] * Ne3.mbts[4]
+  s2_tbt = t_opt[2] * Ne2.mbts[3]
+  for i in 1:F.N
+    for j in 1:F.N
+      for k in 1:F.N
+        s2_tbt[i, j, k, k] += O[i, j]
+        s2_tbt[k, k, i, j] += O[i, j]
+      end
+    end
+  end
+  s3 = F_OP(([0], [0], [0], s_threebt))
+  s2 = F_OP(([0], [0], s2_tbt))
+
+  s1_obt = t_opt[1] * Ne.mbts[2] - 2η * O
+  s1 = F_OP(([-t_opt[1] * η - t_opt[2] * η^2 - t_opt[3] * η^3], s1_obt))
+
+  F_new = F - s1 - s2 - s3
+  println("h_const Bliss:", F_new.mbts[1])
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    create_group(fid, "BLISS")
+    BLISS_group = fid["BLISS"]
+    println("Saving results of BLISS optimization to $SAVENAME")
+    BLISS_group["ovec"] = o_opt
+    BLISS_group["t1"] = t_opt[1]
+    BLISS_group["t2"] = t_opt[2]
+    BLISS_group["t3"] = t_opt[3]
+    BLISS_group["N"] = F.N
+    BLISS_group["Ne"] = η
+    create_group(fid, "BLISS_HAM")
+    MOL_DATA = fid["BLISS_HAM"]
+    MOL_DATA["h_const"] = F_new.mbts[1]
+    MOL_DATA["obt"] = F_new.mbts[2]
+    MOL_DATA["tbt"] = F_new.mbts[3]
+    MOL_DATA["threebt"] = F_new.mbts[4]
+    MOL_DATA["eta"] = η
+    close(fid)
+  end
+
+  println("")
+
+  #println("The L1 cost of symmetry treated fermionic operator is: ", PAULI_L1(F_new))
+  return F_new, s1 + s2 + s3
+end

--- a/src/UTILS/bliss_test.jl
+++ b/src/UTILS/bliss_test.jl
@@ -1,0 +1,80 @@
+using Pkg
+Pkg.add("Arpack")
+Pkg.activate(".")
+Pkg.instantiate()
+Pkg.add("PythonCall")
+using PythonCall
+pyscf = pyimport("pyscf")
+scipy = pyimport("scipy")
+of = pyimport("openfermion")
+np = pyimport("numpy")
+juliacall = pyimport("juliacall")
+UTILS_DIR = @__DIR__
+sys = pyimport("sys")
+sys.path.append(UTILS_DIR)
+fermionic = pyimport("ferm_utils")
+
+function bliss_test(F1::F_OP, F2::F_OP, n_elec)
+  h1e = h1e_to_OF(F1)
+  h2e = h2e_to_OF(F1)
+  h3e = h3e_to_OF(F1)
+
+  # Construct the Hamiltonian
+  hamil = h1e + h2e + h3e
+  sparse_op = of.get_sparse_operator(hamil)
+  energy, vect = of.jw_get_ground_state_at_particle_number(sparse_op, n_elec)
+
+  sparse_op_max = of.get_sparse_operator(-hamil)
+  max_energy, vect = of.jw_get_ground_state_at_particle_number(sparse_op_max, n_elec)
+
+  h1e_bliss = h1e_to_OF(F2)
+  h2e_bliss = h2e_to_OF(F2)
+  h3e_bliss = h3e_to_OF(F2)
+
+  hamil_bliss = h1e_bliss + h2e_bliss + h3e_bliss
+  sparse_op_bliss = of.get_sparse_operator(hamil_bliss)
+  energy_bliss, vect_bliss = of.jw_get_ground_state_at_particle_number(sparse_op_bliss, n_elec)
+
+  sparse_op_max_bliss = of.get_sparse_operator(-hamil_bliss)
+  max_energy_bliss, vect_bliss = of.jw_get_ground_state_at_particle_number(sparse_op_max_bliss, n_elec)
+
+  println("Original Min Energy: ", energy)
+  println("Original Core energy: ", F1.mbts[1][1])
+
+  println("Bliss Min Energy: ", energy_bliss)
+  println("Bliss Core energy: ", F2.mbts[1][1])
+
+  println("Min energy difference:", energy + F1.mbts[1][1] - energy_bliss - F2.mbts[1][1])
+
+
+  println("|Subspace Min Energy original - Energy after Bliss| < 1E-4 ", abs(energy + F1.mbts[1][1] - energy_bliss - F2.mbts[1][1]) < 1E-4)
+
+  println("Spectral range difference: ", -max_energy - energy + max_energy_bliss + energy_bliss)
+  println("|Spectral Range difference| < 1E-4 ", abs(-max_energy - energy + max_energy_bliss + energy_bliss) < 1E-4)
+
+end
+
+
+function h1e_to_OF(F::F_OP)
+  h1e = F.mbts[2]
+  TOT_OP = of.FermionOperator.zero()
+  TOT_OP += fermionic.get_ferm_op_one(h1e, spin_orb=false)
+
+  return TOT_OP
+end
+
+function h2e_to_OF(F::F_OP)
+  h2e = F.mbts[3]
+  TOT_OP = of.FermionOperator.zero()
+  TOT_OP += fermionic.get_ferm_op_two(h2e, spin_orb=false)
+
+  return TOT_OP
+end
+
+function h3e_to_OF(F::F_OP)
+  h3e = F.mbts[4]
+  TOT_OP = of.FermionOperator.zero()
+  TOT_OP += fermionic.get_ferm_op_three(h3e)
+
+  return TOT_OP
+end

--- a/src/UTILS/ferm_utils.py
+++ b/src/UTILS/ferm_utils.py
@@ -217,6 +217,31 @@ def get_ferm_op_two(tbt, spin_orb):
                         )
     return op
 
+def get_ferm_op_three(threebt):
+    num_orbitals = threebt.shape[0]  # assuming h1e is square
+    op = FermionOperator.zero()
+    for p in range(num_orbitals):
+        for q in range(num_orbitals):
+            for r in range(num_orbitals):
+                for s in range(num_orbitals):
+                    for m in range(num_orbitals):
+                        for n in range(num_orbitals):
+                            coefficient = threebt[p, q, r, s, m, n]
+                            if coefficient != 0.0:
+                                term_1 = FermionOperator(((2*p, 1), (2*q, 0), (2*r, 1), (2*s, 0), (2*m, 1), (2*n, 0)), coefficient)
+                                term_2 = FermionOperator(((2*p+1, 1), (2*q+1, 0), (2*r, 1), (2*s, 0), (2*m, 1), (2*n, 0)), coefficient)
+                                term_3 = FermionOperator(((2*p, 1), (2*q, 0), (2*r+1, 1), (2*s+1, 0), (2*m, 1), (2*n, 0)), coefficient)
+                                term_4 = FermionOperator(((2*p, 1), (2*q, 0), (2*r, 1), (2*s, 0), (2*m+1, 1), (2*n+1, 0)), coefficient)
+                                term_5 = FermionOperator(((2*p+1, 1), (2*q+1, 0), (2*r+1, 1), (2*s+1, 0), (2*m, 1), (2*n, 0)), coefficient)
+                                term_6 = FermionOperator(((2*p+1, 1), (2*q+1, 0), (2*r, 1), (2*s, 0), (2*m+1, 1), (2*n+1, 0)), coefficient)
+                                term_7 = FermionOperator(((2*p, 1), (2*q, 0), (2*r+1, 1), (2*s+1, 0), (2*m+1, 1), (2*n+1, 0)), coefficient)
+                                term_8 = FermionOperator(((2*p+1, 1), (2*q+1, 0), (2*r+1, 1), (2*s+1, 0), (2*m+1, 1), (2*n+1, 0)), coefficient)
+
+
+                                op += term_1 + term_2 + term_3 + term_4 + term_5 + term_6 + term_7 + term_8
+    
+    return op
+
 def get_ferm_op(tsr, spin_orb=False):
     '''
     Return the corresponding fermionic operators based on the tensor

--- a/src/UTILS/fermionic.jl
+++ b/src/UTILS/fermionic.jl
@@ -1,603 +1,814 @@
-function to_OP(F :: F_FRAG)
-	# transforms fermionic fragment to operator
-	if F.has_coeff
-		return F.coeff * fermionic_frag_representer(F.nUs, F.U, F.C, F.N, F.spin_orb, F.TECH)
-	else
-		return fermionic_frag_representer(F.nUs, F.U, F.C, F.N, F.spin_orb, F.TECH)
-	end
+function to_OP(F::F_FRAG)
+  # transforms fermionic fragment to operator
+  if F.has_coeff
+    return F.coeff * fermionic_frag_representer(F.nUs, F.U, F.C, F.N, F.spin_orb, F.TECH)
+  else
+    return fermionic_frag_representer(F.nUs, F.U, F.C, F.N, F.spin_orb, F.TECH)
+  end
 end
 
-function F_OP(F :: F_FRAG)
-	return to_OP(F)
+function F_OP(F::F_FRAG)
+  return to_OP(F)
 end
 
-function cartan_1b_to_obt(C :: cartan_1b)
-	obt = Diagonal(C.λ)
+function cartan_1b_to_obt(C::cartan_1b)
+  obt = Diagonal(C.λ)
 
-	return obt
+  return obt
 end
 
-function cartan_2b_to_tbt(C :: cartan_2b)
-	tbt = zeros(Float64,C.N,C.N,C.N,C.N)
+function cartan_2b_to_tbt(C::cartan_2b)
+  tbt = zeros(Float64, C.N, C.N, C.N, C.N)
 
-	idx = 1
-	for i in 1:C.N
-		for j in 1:i
-			tbt[i,i,j,j] = tbt[j,j,i,i] = C.λ[idx]
-			idx += 1
-		end
-	end
+  idx = 1
+  for i in 1:C.N
+    for j in 1:i
+      tbt[i, i, j, j] = tbt[j, j, i, i] = C.λ[idx]
+      idx += 1
+    end
+  end
 
-	return tbt
+  return tbt
 end
 
-function cartan_mat_to_2b(mat :: Array, spin_orb=false)
-	#transforms λij matrix corresponding to two-electron CSA polynomial into cartan_2b structure
-	N = size(mat)[1]
-	λs = zeros(cartan_2b_num_params(N))
+function cartan_mat_to_2b(mat::Array, spin_orb=false)
+  #transforms λij matrix corresponding to two-electron CSA polynomial into cartan_2b structure
+  N = size(mat)[1]
+  λs = zeros(cartan_2b_num_params(N))
 
-	idx = 1
-	for i in 1:N
-		for j in 1:i
-			λs[idx] = (mat[i,j] + mat[j,i])/2
-			idx += 1
-		end
-	end
+  idx = 1
+  for i in 1:N
+    for j in 1:i
+      λs[idx] = (mat[i, j] + mat[j, i]) / 2
+      idx += 1
+    end
+  end
 
-	return cartan_2b(spin_orb, λs, N)
+  return cartan_2b(spin_orb, λs, N)
 end
 
 function cartan_2b_num_params(N)
-	return Int(N*(N+1)/2)
+  return Int(N * (N + 1) / 2)
 end
 
 function cartan_SD_num_params(N)
-	return N + cartan_2b_num_params(N)
+  return N + cartan_2b_num_params(N)
 end
 
-function cartan_SD_to_F_OP(C :: cartan_SD)
-	obt = Diagonal(C.λ1)
-	
-	tbt = zeros(Float64,C.N,C.N,C.N,C.N)
+function cartan_SD_to_F_OP(C::cartan_SD)
+  obt = Diagonal(C.λ1)
 
-	idx = 1
-	for i in 1:C.N
-		for j in 1:i
-			tbt[i,i,j,j] = tbt[j,j,i,i] = C.λ2[idx]
-			idx += 1
-		end
-	end	
+  tbt = zeros(Float64, C.N, C.N, C.N, C.N)
 
-	return F_OP(([0], obt, tbt), C.spin_orb)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: CSA)
-	if nUs != 1
-		error("Trying to build CSA fragment with $nUs unitaries defined, should be 1!")
-	end
-	tbt = cartan_2b_to_tbt(C)
-	Urot = one_body_unitary(U[1])
-	tbt = cartan_tbt_rotation(Urot, tbt, N)
-
-	return F_OP(2,([0.0], [0.0], tbt), [false,false,true], spin_orb, N)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: CSA_SD)
-	if nUs != 1
-		error("Trying to build CSA fragment with $nUs unitaries defined, should be 1!")
-	end
-	F = cartan_SD_to_F_OP(C)
-
-	return F_OP_rotation(U[1], F)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: DF)
-	if nUs != 1
-		error("Trying to build DF fragment with $nUs unitaries defined, should be 1!")
-	end
-	Urot = one_body_unitary(U[1])
-
-	tbt = zeros(Float64,N,N,N,N)
-	for i in 1:N
-		tbt[i,i,i,i] = C.λ[i]^2
-		for j in i+1:N
-			tbt[i,i,j,j] = tbt[j,j,i,i] = C.λ[i] * C.λ[j]
-		end
-	end
-
-	if typeof(Urot[1]) <: Complex
-		tbt = cartan_tbt_complex_rotation(Urot, tbt, N)
-		println("Complex rotation!")
-	else
-		tbt = cartan_tbt_rotation(Urot, tbt, N)
-	end
-
-	return F_OP(2,([0.0], [0.0], tbt), [false,false,true], spin_orb, N)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: OBF)
-	if nUs != 1
-		error("Trying to build OBF fragment with $nUs unitaries defined, should be 1!")
-	end
-	Urot = one_body_unitary(U[1])
-
-	obt = collect(Diagonal(C.λ))
-
-	if typeof(Urot[1]) <: Complex
-		obt = cartan_obt_complex_rotation(Urot, obt, N)
-		println("Complex rotation!")
-	else
-		obt = cartan_obt_rotation(Urot, obt, N)
-	end
-
-	return F_OP(1,([0.0], obt), [false,true], spin_orb, N)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: THC)
-	if nUs != 2
-		error("Trying to build H_THC fragment with $nUs unitaries defined, should be 2!")
-	end
-	U1 = one_body_unitary(U[1])
-	U2 = one_body_unitary(U[2])
-
-	tbt = zeros(Float64,N,N,N,N)
-	@einsum tbt[a,b,c,d] = U1[a,1] * U1[b,1] * U2[c,1] * U2[d,1]
-	@einsum tbt[a,b,c,d] += U2[a,1] * U2[b,1] * U1[c,1] * U1[d,1]
-
-	return F_OP(2,([0.0], [0.0], tbt), [false,false,true], spin_orb, N)
-end
-
-function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH :: MTD_CP4)
-	if nUs != 4
-		error("Trying to build MTD_CP4 fragment with $nUs unitaries defined, should be 4!")
-	end
-	U1 = one_body_rotation_coeffs(U[1])
-	U2 = one_body_rotation_coeffs(U[2])
-	U3 = one_body_rotation_coeffs(U[3])
-	U4 = one_body_rotation_coeffs(U[4])
-
-	tbt = zeros(Float64,N,N,N,N)
-	@einsum tbt[a,b,c,d] = U1[a] * U2[b] * U3[c] * U4[d]
-	
-	return F_OP(2,([0], [0], tbt), [false,false,true], spin_orb, N)
-end
-
-function obt_to_tbt(obt, imag_tol = 1e-8)
-	## transform one-body tensor into two-body tensor
-    ## requires obt to be in spin-orbitals!
-    
-    #println("Transforming one-body tensor into two-body object, small numerical errors might appear...")
-	
-    Dobt, Uobt = eigen(obt)
-    #obt ≡ Uobt * Diagonal(Dobt) * (Uobt')
-
-    n = size(obt)[1]
-
-    tbt = zeros(typeof(Uobt[1]),n,n,n,n)
-    for i in 1:n
-        tbt[i,i,i,i] = Dobt[i]
+  idx = 1
+  for i in 1:C.N
+    for j in 1:i
+      tbt[i, i, j, j] = tbt[j, j, i, i] = C.λ2[idx]
+      idx += 1
     end
+  end
 
-    rotated_tbt = zeros(typeof(Uobt[1]),n,n,n,n)
+  return F_OP(([0], obt, tbt), C.spin_orb)
+end
 
-    @einsum rotated_tbt[a,b,c,d] = Uobt[a,l] * conj(Uobt[b,l]) * Uobt[c,l] * conj(Uobt[d,l]) * tbt[l,l,l,l]
-    
-    if sum(abs.(imag.(rotated_tbt))) < imag_tol
-    	return real.(rotated_tbt)
-    else
-    	return rotated_tbt
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::CSA)
+  if nUs != 1
+    error("Trying to build CSA fragment with $nUs unitaries defined, should be 1!")
+  end
+  tbt = cartan_2b_to_tbt(C)
+  Urot = one_body_unitary(U[1])
+  tbt = cartan_tbt_rotation(Urot, tbt, N)
+
+  return F_OP(2, ([0.0], [0.0], tbt), [false, false, true], spin_orb, N)
+end
+
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::CSA_SD)
+  if nUs != 1
+    error("Trying to build CSA fragment with $nUs unitaries defined, should be 1!")
+  end
+  F = cartan_SD_to_F_OP(C)
+
+  return F_OP_rotation(U[1], F)
+end
+
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::DF)
+  if nUs != 1
+    error("Trying to build DF fragment with $nUs unitaries defined, should be 1!")
+  end
+  Urot = one_body_unitary(U[1])
+
+  tbt = zeros(Float64, N, N, N, N)
+  for i in 1:N
+    tbt[i, i, i, i] = C.λ[i]^2
+    for j in i+1:N
+      tbt[i, i, j, j] = tbt[j, j, i, i] = C.λ[i] * C.λ[j]
     end
+  end
+
+  if typeof(Urot[1]) <: Complex
+    tbt = cartan_tbt_complex_rotation(Urot, tbt, N)
+    println("Complex rotation!")
+  else
+    tbt = cartan_tbt_rotation(Urot, tbt, N)
+  end
+
+  return F_OP(2, ([0.0], [0.0], tbt), [false, false, true], spin_orb, N)
+end
+
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::OBF)
+  if nUs != 1
+    error("Trying to build OBF fragment with $nUs unitaries defined, should be 1!")
+  end
+  Urot = one_body_unitary(U[1])
+
+  obt = collect(Diagonal(C.λ))
+
+  if typeof(Urot[1]) <: Complex
+    obt = cartan_obt_complex_rotation(Urot, obt, N)
+    println("Complex rotation!")
+  else
+    obt = cartan_obt_rotation(Urot, obt, N)
+  end
+
+  return F_OP(1, ([0.0], obt), [false, true], spin_orb, N)
+end
+
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::THC)
+  if nUs != 2
+    error("Trying to build H_THC fragment with $nUs unitaries defined, should be 2!")
+  end
+  U1 = one_body_unitary(U[1])
+  U2 = one_body_unitary(U[2])
+
+  tbt = zeros(Float64, N, N, N, N)
+  @einsum tbt[a, b, c, d] = U1[a, 1] * U1[b, 1] * U2[c, 1] * U2[d, 1]
+  @einsum tbt[a, b, c, d] += U2[a, 1] * U2[b, 1] * U1[c, 1] * U1[d, 1]
+
+  return F_OP(2, ([0.0], [0.0], tbt), [false, false, true], spin_orb, N)
+end
+
+function fermionic_frag_representer(nUs, U, C, N, spin_orb, TECH::MTD_CP4)
+  if nUs != 4
+    error("Trying to build MTD_CP4 fragment with $nUs unitaries defined, should be 4!")
+  end
+  U1 = one_body_rotation_coeffs(U[1])
+  U2 = one_body_rotation_coeffs(U[2])
+  U3 = one_body_rotation_coeffs(U[3])
+  U4 = one_body_rotation_coeffs(U[4])
+
+  tbt = zeros(Float64, N, N, N, N)
+  @einsum tbt[a, b, c, d] = U1[a] * U2[b] * U3[c] * U4[d]
+
+  return F_OP(2, ([0], [0], tbt), [false, false, true], spin_orb, N)
+end
+
+function obt_to_tbt(obt, imag_tol=1e-8)
+  ## transform one-body tensor into two-body tensor
+  ## requires obt to be in spin-orbitals!
+
+  #println("Transforming one-body tensor into two-body object, small numerical errors might appear...")
+
+  Dobt, Uobt = eigen(obt)
+  #obt ≡ Uobt * Diagonal(Dobt) * (Uobt')
+
+  n = size(obt)[1]
+
+  tbt = zeros(typeof(Uobt[1]), n, n, n, n)
+  for i in 1:n
+    tbt[i, i, i, i] = Dobt[i]
+  end
+
+  rotated_tbt = zeros(typeof(Uobt[1]), n, n, n, n)
+
+  @einsum rotated_tbt[a, b, c, d] = Uobt[a, l] * conj(Uobt[b, l]) * Uobt[c, l] * conj(Uobt[d, l]) * tbt[l, l, l, l]
+
+  if sum(abs.(imag.(rotated_tbt))) < imag_tol
+    return real.(rotated_tbt)
+  else
+    return rotated_tbt
+  end
 end
 
 function tbt_orb_to_so(tbt)
-	#transform two-body tensor in spacial-orbitals to spin-orbitals
-    n = size(tbt)[1]
-    n_qubit = 2n
+  #transform two-body tensor in spacial-orbitals to spin-orbitals
+  n = size(tbt)[1]
+  n_qubit = 2n
 
-    tbt_so = zeros(2n,2n,2n,2n)
-    for i1 in 1:n
-        for i2 in 1:n
-            for i3 in 1:n
-                for i4 in 1:n
-                    for a in -1:0
-                        for b in -1:0
-                            tbt_so[2i1+a,2i2+a,2i3+b,2i4+b] = tbt[i1,i2,i3,i4]
-                        end
-                    end
-                end
+  tbt_so = zeros(2n, 2n, 2n, 2n)
+  for i1 in 1:n
+    for i2 in 1:n
+      for i3 in 1:n
+        for i4 in 1:n
+          for a in -1:0
+            for b in -1:0
+              tbt_so[2i1+a, 2i2+a, 2i3+b, 2i4+b] = tbt[i1, i2, i3, i4]
             end
+          end
         end
+      end
     end
+  end
 
-    return tbt_so
+  return tbt_so
 end
 
-function tbt_so_to_orb(tbt_so; tiny = 1e-16)
-	#transform two-body tensor in spin-orbitals to spacial-orbitals, will fail if non-symmetric
-	n_so = size(tbt_so)[1]
-	n = Int(n_so/2)
+function tbt_so_to_orb(tbt_so; tiny=1e-16)
+  #transform two-body tensor in spin-orbitals to spacial-orbitals, will fail if non-symmetric
+  n_so = size(tbt_so)[1]
+  n = Int(n_so / 2)
 
-	tbt = zeros(n,n,n,n)
-	for i1 in 1:n
-        for i2 in 1:n
-            for i3 in 1:n
-                for i4 in 1:n
-                    tbt[i1,i2,i3,i4] = tbt_so[2i1,2i2,2i3,2i4]
-                end
-            end
+  tbt = zeros(n, n, n, n)
+  for i1 in 1:n
+    for i2 in 1:n
+      for i3 in 1:n
+        for i4 in 1:n
+          tbt[i1, i2, i3, i4] = tbt_so[2i1, 2i2, 2i3, 2i4]
         end
+      end
     end
+  end
 
-    if sum(abs2.(tbt_so - tbt_orb_to_so(tbt))) > tiny
-    	@show sum(abs2.(tbt_so - tbt_orb_to_so(tbt)))
-    	error("Failed converting spin-orbital two-body tensor into spacial orbitals, non-symmetric!")
-    end
+  if sum(abs2.(tbt_so - tbt_orb_to_so(tbt))) > tiny
+    @show sum(abs2.(tbt_so - tbt_orb_to_so(tbt)))
+    error("Failed converting spin-orbital two-body tensor into spacial orbitals, non-symmetric!")
+  end
 
-    return tbt
+  return tbt
 end
 
 function obt_orb_to_so(obt)
-	#transform one-body tensor in spacial-orbitals to spin-orbitals
-    n = size(obt)[1]
-    n_qubit = 2n
+  #transform one-body tensor in spacial-orbitals to spin-orbitals
+  n = size(obt)[1]
+  n_qubit = 2n
 
-    obt_so = zeros(2n,2n)
-    for i1 in 1:n
-        for i2 in 1:n
-            for a in -1:0
-                obt_so[2i1+a,2i2+a] = obt[i1,i2]
-            end
-        end
+  obt_so = zeros(2n, 2n)
+  for i1 in 1:n
+    for i2 in 1:n
+      for a in -1:0
+        obt_so[2i1+a, 2i2+a] = obt[i1, i2]
+      end
     end
+  end
 
-    return obt_so
+  return obt_so
 end
 
 function obt_so_to_orb(obt_so; tiny=1e-16)
-	#transform one-body tensor in spin-orbitals to spacial-orbitals, will fail if non-symmetric
-    n_so = size(obt_so)[1]
-    n = Int(n_so/2)
+  #transform one-body tensor in spin-orbitals to spacial-orbitals, will fail if non-symmetric
+  n_so = size(obt_so)[1]
+  n = Int(n_so / 2)
 
-    obt = zeros(n,n)
-    for i1 in 1:n
-        for i2 in 1:n
-            obt[i1,i2] = obt_so[2i1,2i2]
-        end
+  obt = zeros(n, n)
+  for i1 in 1:n
+    for i2 in 1:n
+      obt[i1, i2] = obt_so[2i1, 2i2]
     end
+  end
 
-	if sum(abs2.(obt_so - obt_orb_to_so(obt))) > tiny
-		@show sum(abs2.(obt_so - tbt_orb_to_so(obt)))
-    	error("Failed converting spin-orbital two-body tensor into spacial orbitals, non-symmetric!")
-    end
+  if sum(abs2.(obt_so - obt_orb_to_so(obt))) > tiny
+    @show sum(abs2.(obt_so - tbt_orb_to_so(obt)))
+    error("Failed converting spin-orbital two-body tensor into spacial orbitals, non-symmetric!")
+  end
 
-    return obt
+  return obt
 end
 
 function mbt_orb_to_so(mbt)
-	#transforms orbital many-body fermionic tensor into spin-orbitals
-	error("Not implemented!")
+  #transforms orbital many-body fermionic tensor into spin-orbitals
+  error("Not implemented!")
 end
 
-function to_SO(F :: F_OP)
-	#returns operator in spin-orbitals (i.e. spin_orb = true)
-	#conversion is not very efficient, shouldn't be used often!
-	if F.spin_orb == true
-		#println("Fermionic operator is already in spin-orbitals, nothing was done...")
-		return F
-	elseif F.Nbods == 1
-		mbts = (F.mbts[1], obt_orb_to_so(F.mbts[2]))
-	elseif F.Nbods == 2
-		if F.filled[2]
-			mbts = (F.mbts[1], obt_orb_to_so(F.mbts[2]), tbt_orb_to_so(F.mbts[3]))
-		else
-			mbts = (F.mbts[1], [0.0], tbt_orb_to_so(F.mbts[3]))
-		end
-	elseif F.Nbods > 2
-		M_arr = Array{Float64}[]
-		for i in 1:N
-			if !F.filled[i]
-				push!(M_arr,[0.0])
-			else
-				push!(M_arr, mbt_orb_to_so(mbt[i]))
-			end
-		end
-		mbts = tuple(M_arr...)
-	end
+function to_SO(F::F_OP)
+  #returns operator in spin-orbitals (i.e. spin_orb = true)
+  #conversion is not very efficient, shouldn't be used often!
+  if F.spin_orb == true
+    #println("Fermionic operator is already in spin-orbitals, nothing was done...")
+    return F
+  elseif F.Nbods == 1
+    mbts = (F.mbts[1], obt_orb_to_so(F.mbts[2]))
+  elseif F.Nbods == 2
+    if F.filled[2]
+      mbts = (F.mbts[1], obt_orb_to_so(F.mbts[2]), tbt_orb_to_so(F.mbts[3]))
+    else
+      mbts = (F.mbts[1], [0.0], tbt_orb_to_so(F.mbts[3]))
+    end
+  elseif F.Nbods > 2
+    M_arr = Array{Float64}[]
+    for i in 1:N
+      if !F.filled[i]
+        push!(M_arr, [0.0])
+      else
+        push!(M_arr, mbt_orb_to_so(mbt[i]))
+      end
+    end
+    mbts = tuple(M_arr...)
+  end
 
-	return F_OP(copy(F.Nbods),mbts,copy(F.filled),true,2*F.N)
+  return F_OP(copy(F.Nbods), mbts, copy(F.filled), true, 2 * F.N)
 end
 
 import Base.+
 
-function +(F1 :: F_OP, F2 :: F_OP)
-	Nmax = maximum([F1.Nbods, F2.Nbods])
-	filled = ones(Bool, Nmax+1)
-	M_arr = Array{Float64}[]
+function +(F1::F_OP, F2::F_OP)
+  Nmax = maximum([F1.Nbods, F2.Nbods])
+  filled = ones(Bool, Nmax + 1)
+  M_arr = Array{Float64}[]
 
-	if F1.spin_orb != F2.spin_orb
-		println("Summing spin-orbital with orbital fermionic operators, converting both to spin-orbitals...")
-		return +(to_SO(F1), to_SO(F2))
-	end
+  if F1.spin_orb != F2.spin_orb
+    println("Summing spin-orbital with orbital fermionic operators, converting both to spin-orbitals...")
+    return +(to_SO(F1), to_SO(F2))
+  end
 
-	if F1.N != F2.N
-		@show F1.N
-		@show F2.N
-		error("Trying to sum fermionic operators over different number of orbitals!")
-	end
+  if F1.N != F2.N
+    @show F1.N
+    @show F2.N
+    error("Trying to sum fermionic operators over different number of orbitals!")
+  end
 
-	filled_1 = zeros(Bool,Nmax+1)
-	filled_2 = zeros(Bool,Nmax+1)
-	filled_1[1:F1.Nbods+1] = F1.filled
-	filled_2[1:F2.Nbods+1] = F2.filled
+  filled_1 = zeros(Bool, Nmax + 1)
+  filled_2 = zeros(Bool, Nmax + 1)
+  filled_1[1:F1.Nbods+1] = F1.filled
+  filled_2[1:F2.Nbods+1] = F2.filled
 
-	for i in 1:Nmax+1
-		if filled_1[i] == false
-			if filled_2[i] == false
-				push!(M_arr,[0.0])
-				filled[i] = false
-			else
-				push!(M_arr,F2.mbts[i])
-			end
-		else
-			if filled_2[i] == false
-				push!(M_arr,F1.mbts[i])
-			else
-				push!(M_arr,F1.mbts[i] + F2.mbts[i])
-			end
-		end
-	end
+  for i in 1:Nmax+1
+    if filled_1[i] == false
+      if filled_2[i] == false
+        push!(M_arr, [0.0])
+        filled[i] = false
+      else
+        push!(M_arr, F2.mbts[i])
+      end
+    else
+      if filled_2[i] == false
+        push!(M_arr, F1.mbts[i])
+      else
+        push!(M_arr, F1.mbts[i] + F2.mbts[i])
+      end
+    end
+  end
 
-	return F_OP(Nmax, tuple(M_arr...), filled, F1.spin_orb, F1.N)
+  return F_OP(Nmax, tuple(M_arr...), filled, F1.spin_orb, F1.N)
 end
 
 import Base.*
 
-function *(F :: F_OP, a :: Real)
-	return F_OP(F.Nbods, a .* F.mbts, F.filled, F.spin_orb, F.N)
+function *(F::F_OP, a::Real)
+  return F_OP(F.Nbods, a .* F.mbts, F.filled, F.spin_orb, F.N)
 end
 
-function *(a :: Real, F :: F_OP)
-	return F_OP(F.Nbods, a .* F.mbts, F.filled, F.spin_orb, F.N)
+function *(a::Real, F::F_OP)
+  return F_OP(F.Nbods, a .* F.mbts, F.filled, F.spin_orb, F.N)
 end
 
 import Base.-
 
-function -(F1 :: F_OP, F2 :: F_OP)
-	return F1 + (-1 * F2)
+function -(F1::F_OP, F2::F_OP)
+  return F1 + (-1 * F2)
 end
 
-+(F1 :: F_OP, F2 :: F_FRAG) = F1 + F_OP(F2)
-+(F1 :: F_FRAG, F2 :: F_OP) = F_OP(F1) + F2
-+(F1 :: F_FRAG, F2 :: F_FRAG) = F_OP(F1) + F_OP(F2)
++(F1::F_OP, F2::F_FRAG) = F1 + F_OP(F2)
++(F1::F_FRAG, F2::F_OP) = F_OP(F1) + F2
++(F1::F_FRAG, F2::F_FRAG) = F_OP(F1) + F_OP(F2)
 
--(F1 :: F_OP, F2 :: F_FRAG) = F1 - F_OP(F2)
--(F1 :: F_FRAG, F2 :: F_OP) = F_OP(F1) - F2
--(F1 :: F_FRAG, F2 :: F_FRAG) = F_OP(F1) - F_OP(F2)
+-(F1::F_OP, F2::F_FRAG) = F1 - F_OP(F2)
+-(F1::F_FRAG, F2::F_OP) = F_OP(F1) - F2
+-(F1::F_FRAG, F2::F_FRAG) = F_OP(F1) - F_OP(F2)
 
 
-function F_OP_collect_obt(F :: F_OP)
-	#return fermionic operator with one-body tensor collected into two-body tensor
-	if F.Nbods < 1
-		error("No one-body tensor to collect in fermionic operator!")
-	elseif F.Nbods == 1
-		F_mid = to_SO(F)
-		tbt = obt_to_tbt(F_mid.mbts[2])
-		mbts = (F_mid.mbts[1], [0.0], tbt)
-		filled = [F_mid.filled[1], false, true]
-		Nret = F_mid.N
-	else
-		if F.spin_orb == false
-			F_mid = to_SO(F)
-			tbt = F_mid.mbts[3] + obt_to_tbt(F_mid.mbts[2])
-			mbts = tuple(F_mid.mbts[1], [0.0], tbt, F_mid.mbts[4:end])
-			filled = F_mid.filled
-			filled[2] = false
-			Nret = F_mid.N
-		else
-			tbt = F.mbts[3] + obt_to_tbt(F.mbts[2])
-			mbts = tuple(F.mbts[1], [0.0], tbt, F.mbts[4:end]...)
-			filled = F.filled
-			filled[2] = false
-			Nret = F.N
-		end
-	end
+function F_OP_collect_obt(F::F_OP)
+  #return fermionic operator with one-body tensor collected into two-body tensor
+  if F.Nbods < 1
+    error("No one-body tensor to collect in fermionic operator!")
+  elseif F.Nbods == 1
+    F_mid = to_SO(F)
+    tbt = obt_to_tbt(F_mid.mbts[2])
+    mbts = (F_mid.mbts[1], [0.0], tbt)
+    filled = [F_mid.filled[1], false, true]
+    Nret = F_mid.N
+  else
+    if F.spin_orb == false
+      F_mid = to_SO(F)
+      tbt = F_mid.mbts[3] + obt_to_tbt(F_mid.mbts[2])
+      mbts = tuple(F_mid.mbts[1], [0.0], tbt, F_mid.mbts[4:end])
+      filled = F_mid.filled
+      filled[2] = false
+      Nret = F_mid.N
+    else
+      tbt = F.mbts[3] + obt_to_tbt(F.mbts[2])
+      mbts = tuple(F.mbts[1], [0.0], tbt, F.mbts[4:end]...)
+      filled = F.filled
+      filled[2] = false
+      Nret = F.N
+    end
+  end
 
-	return F_OP(F.Nbods, mbts, filled, true, Nret)
+  return F_OP(F.Nbods, mbts, filled, true, Nret)
 end
 
 import Base.copy
 
-copy(F :: F_OP) = 0 * F + F
-copy(F :: F_FRAG) = F_FRAG(F.nUs, F.U, F.TECH, F.C, F.N, F.spin_orb, F.coeff, F.has_coeff)
+copy(F::F_OP) = 0 * F + F
+copy(F::F_FRAG) = F_FRAG(F.nUs, F.U, F.TECH, F.C, F.N, F.spin_orb, F.coeff, F.has_coeff)
 
-function CSA_x_to_F_FRAG(x, N, spin_orb, cartan_L = Int(N*(N+1)/2); do_Givens = CSA_GIVENS)
-	if do_Givens
-		return F_FRAG(1,tuple(givens_real_orbital_rotation(N, x[cartan_L+1:end])),CSA(),cartan_2b(spin_orb,x[1:cartan_L],N),N, spin_orb)
-	else
-		return F_FRAG(1,tuple(real_orbital_rotation(N, x[cartan_L+1:end])),CSA(),cartan_2b(spin_orb,x[1:cartan_L],N),N, spin_orb)
-	end
+function CSA_x_to_F_FRAG(x, N, spin_orb, cartan_L=Int(N * (N + 1) / 2); do_Givens=CSA_GIVENS)
+  if do_Givens
+    return F_FRAG(1, tuple(givens_real_orbital_rotation(N, x[cartan_L+1:end])), CSA(), cartan_2b(spin_orb, x[1:cartan_L], N), N, spin_orb)
+  else
+    return F_FRAG(1, tuple(real_orbital_rotation(N, x[cartan_L+1:end])), CSA(), cartan_2b(spin_orb, x[1:cartan_L], N), N, spin_orb)
+  end
 end
 
-function CSA_SD_x_to_F_FRAG(x, N, spin_orb, cartan_L = Int(N*(N+1)/2); do_Givens = CSA_GIVENS)
-	if do_Givens
-		return F_FRAG(1,tuple(givens_real_orbital_rotation(N, x[cartan_L+N+1:end])),CSA_SD(),cartan_SD(spin_orb,x[1:N],x[N+1:N+cartan_L],N),N, spin_orb)
-	else
-		return F_FRAG(1,tuple(real_orbital_rotation(N, x[cartan_L+N+1:end])),CSA_SD(),cartan_SD(spin_orb,x[1:N],x[N+1:N+cartan_L],N),N, spin_orb)
-	end
+function CSA_SD_x_to_F_FRAG(x, N, spin_orb, cartan_L=Int(N * (N + 1) / 2); do_Givens=CSA_GIVENS)
+  if do_Givens
+    return F_FRAG(1, tuple(givens_real_orbital_rotation(N, x[cartan_L+N+1:end])), CSA_SD(), cartan_SD(spin_orb, x[1:N], x[N+1:N+cartan_L], N), N, spin_orb)
+  else
+    return F_FRAG(1, tuple(real_orbital_rotation(N, x[cartan_L+N+1:end])), CSA_SD(), cartan_SD(spin_orb, x[1:N], x[N+1:N+cartan_L], N), N, spin_orb)
+  end
 end
 
 function MTD_CP4_x_to_F_FRAG(x, N, spin_orb=false)
-	Uvecs = reshape(x[1:end-1], (N-1,4))
-	omega = x[end]
+  Uvecs = reshape(x[1:end-1], (N - 1, 4))
+  omega = x[end]
 
-	Us = tuple([single_majorana_rotation(N, Uvecs[:,i]) for i in 1:4]...)
-	return F_FRAG(4, Us, MTD_CP4(), cartan_m1(), N, spin_orb, omega, true)
+  Us = tuple([single_majorana_rotation(N, Uvecs[:, i]) for i in 1:4]...)
+  return F_FRAG(4, Us, MTD_CP4(), cartan_m1(), N, spin_orb, omega, true)
 end
 
 function THC_x_to_F_FRAGS(x, α, N)
-	num_ζ = Int(α*(α+1)/2) #ζij is non-zero only for i≥j since operators are hermitized
-	ζ = x[1:num_ζ]
-	θs = reshape(x[num_ζ+1:end], N-1, α)
-	FRAGS = F_FRAG[]
+  num_ζ = Int(α * (α + 1) / 2) #ζij is non-zero only for i≥j since operators are hermitized
+  ζ = x[1:num_ζ]
+  θs = reshape(x[num_ζ+1:end], N - 1, α)
+  FRAGS = F_FRAG[]
 
-	idx = 1
-	for i in 1:α
-		Ui = restricted_orbital_rotation(N, θs[:,i])
-		for j in 1:i
-			Uj = restricted_orbital_rotation(N, θs[:,j])
-			frag = F_FRAG(2, (Ui,Uj), THC(), cartan_m1(), N, false, ζ[idx], true)
-			push!(FRAGS, frag)
-			idx += 1
-		end
-	end
+  idx = 1
+  for i in 1:α
+    Ui = restricted_orbital_rotation(N, θs[:, i])
+    for j in 1:i
+      Uj = restricted_orbital_rotation(N, θs[:, j])
+      frag = F_FRAG(2, (Ui, Uj), THC(), cartan_m1(), N, false, ζ[idx], true)
+      push!(FRAGS, frag)
+      idx += 1
+    end
+  end
 
-	return FRAGS
+  return FRAGS
 end
 
-function ob_correction(F :: F_OP; return_op=false)
-	#returns correction to one-body tensor coming from tbt inside fermionic operator F
-	if F.spin_orb
-		obt = sum([F.mbts[3][:,:,r,r] for r in 1:F.N])
-	else
-		obt = 2*sum([F.mbts[3][:,:,r,r] for r in 1:F.N])
-	end
-	
-	if return_op
-		return F_OP(([0], obt), F.spin_orb)
-	else
-		return obt
-	end
+function ob_correction(F::F_OP; return_op=false)
+  #returns correction to one-body tensor coming from tbt inside fermionic operator F
+  if F.spin_orb
+    obt = sum([F.mbts[3][:, :, r, r] for r in 1:F.N])
+  else
+    if size(F.mbts[2], 1) == size(F.mbts[3], 1)
+      obt = 2 * sum([F.mbts[3][:, :, r, r] for r in 1:F.N])
+    else
+      obt = zeros(2, F.N, F.N)
+
+      obt[1, :, :] .= sum([F.mbts[3][1, :, :, r, r] for r in 1:F.N]) + sum([F.mbts[3][2, :, :, r, r] for r in 1:F.N])
+      obt[2, :, :] .= sum([F.mbts[3][3, :, :, r, r] for r in 1:F.N]) + sum([F.mbts[3][4, :, :, r, r] for r in 1:F.N])
+    end
+  end
+
+  if return_op
+    return F_OP(([0], obt), F.spin_orb)
+  else
+    return obt
+  end
 end
 
-function ob_correction(tbt :: Array{Float64, 4}, spin_orb=false)
-	N = size(tbt)[1]
-	if spin_orb
-		return sum([tbt[:,:,r,r] for r in 1:N])
-	else
-		return 2*sum([tbt[:,:,r,r] for r in 1:N])
-	end
+function ob_correction_3bd_1(F::F_OP, i, j; return_op=false)
+  obt = 1 / 8 * sum(F.mbts[4][k, l, i, j, k, l] for k in 1:F.N, l in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][k, l, i, l, k, j] for k in 1:F.N, l in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][k, j, i, l, k, l] for k in 1:F.N, l in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][k, l, k, j, i, l] for k in 1:F.N, l in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][k, l, k, l, i, j] for k in 1:F.N, l in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][k, j, k, l, i, l] for k in 1:F.N, l in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][i, l, k, j, k, l] for k in 1:F.N, l in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][i, l, k, l, k, j] for k in 1:F.N, l in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][i, j, k, l, k, l] for k in 1:F.N, l in 1:F.N)
+  return obt
+end
+function ob_correction_3bd_2(F::F_OP, i, j; return_op=false)
+  obt = 1 / 8 * sum(F.mbts[4][k, j, k, j, i, j] for k in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][k, j, i, j, k, j] for k in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][i, j, k, j, k, j] for k in 1:F.N)
+  obt += -1 / 8 * sum(F.mbts[4][j, k, i, j, i, k] for k in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][i, k, i, k, i, j] for k in 1:F.N)
+  obt += 1 / 8 * sum(F.mbts[4][i, j, i, k, j, k] for k in 1:F.N)
+  return obt
 end
 
-function ob_correction(F :: F_FRAG; return_op = false)
-	if return_op == false
-		return ob_correction(to_OP(F))
-	else
-		return F_OP(([0],ob_correction(to_OP(F))))
-	end
+function ob_correction_3bd_3(F::F_OP, i, j; return_op=false)
+  obt = -1 / 8 * F.mbts[4][i, j, i, j, i, j]
+  return obt
 end
 
-function initialize_FRAG(N :: Int64, TECH :: DF; REAL=true)
-	nUs = 1
-	if REAL
-		U = tuple(real_orbital_rotation(N, zeros(Int(N*(N-1)/2))))
-	else
-		U = tuple(orbital_rotation(N, zeros(Int(N^2))))
-	end
-	C = cartan_1b(false, zeros(N), N)
-
-	return F_FRAG(nUs, U, DF(), C, N, false, 1, false)
+function ob_correction_3bd_4(F::F_OP, i, j; return_op=false)
+  obt = 3 / 2 * sum(F.mbts[4][i, j, k, k, l, l] for k in 1:F.N, l in 1:F.N)
+  return obt
 end
 
-function initialize_FRAG(N :: Int64, TECH :: CSA; REAL=true)
-	nUs = 1
-	if REAL
-		U = tuple(real_orbital_rotation(N, zeros(Int(N*(N-1)/2))))
-	else
-		U = tuple(orbital_rotation(N, zeros(Int(N^2))))
-	end
-	C = cartan_2b(false, zeros(Int(N*(N+1)/2)), N)
+function ob_correction_3bd(F::F_OP; return_op=false)
+  #returns correction to one-body tensor coming from three body term inside fermionic operator F
+  if F.spin_orb
+    return F
+  else
+    if size(F.mbts[2], 1) == size(F.mbts[3], 1) && size(F.mbts[3], 1) == size(F.mbts[4], 1)
+      obt = 1 / 8 * sum(F.mbts[4][k, l, :, :, k, l] for k in 1:F.N, l in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][k, l, :, l, k, :] for k in 1:F.N, l in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][k, :, :, l, k, l] for k in 1:F.N, l in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][k, l, k, :, :, l] for k in 1:F.N, l in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][k, l, k, l, :, :] for k in 1:F.N, l in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][k, :, k, l, :, l] for k in 1:F.N, l in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][:, l, k, :, k, l] for k in 1:F.N, l in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][:, l, k, l, k, :] for k in 1:F.N, l in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][:, :, k, l, k, l] for k in 1:F.N, l in 1:F.N)
 
-	return F_FRAG(nUs, U, CSA(), C, N, false, 1, false)
+      obt += 1 / 8 * sum(F.mbts[4][k, :, k, :, :, :] for k in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][k, :, :, :, k, :] for k in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][:, :, k, :, k, :] for k in 1:F.N)
+      obt += -1 / 8 * sum(F.mbts[4][:, k, :, :, :, k] for k in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][:, k, :, k, :, :] for k in 1:F.N)
+      obt += 1 / 8 * sum(F.mbts[4][:, :, :, k, :, k] for k in 1:F.N)
+
+      obt += -1 / 8 * F.mbts[4][:, :, :, :, :, :]
+
+      obt += 3 / 2 * sum(F.mbts[4][:, :, k, k, l, l] for k in 1:F.N, l in 1:F.N)
+
+    else
+      return F
+    end
+  end
+
+  if return_op
+    return F_OP(([0], obt), F.spin_orb)
+  else
+    return obt
+  end
 end
 
-function initialize_FRAG(N :: Int64, TECH :: THC; REAL=true)
-	nUs = 2
-	if REAL
-		U = tuple(real_orbital_rotation(N, zeros(Int(N*(N-1)/2))),
-				  real_orbital_rotation(N, zeros(Int(N*(N-1)/2))))
-	else
-		U = tuple(orbital_rotation(N, zeros(Int(N^2))),
-				  orbital_rotation(N, zeros(Int(N^2))))
-	end
-	C = cartan_m1()
+function tb_correction_1(F::F_OP; return_op=false)
+  #returns correction to one-body tensor coming from tbt inside fermionic operator F
+  if F.spin_orb
+    return F
+  else
+    if size(F.mbts[3], 1) == size(F.mbts[4], 1)
+      tbt = 3 * sum(F.mbts[4][:, :, :, :, m, m] for m in 1:F.N)
+    else
+      return F
+    end
+  end
 
-	return F_FRAG(nUs, U, THC(), C, N, false, 1, true)
+  if return_op
+    return F_OP(([0], [0], tbt), F.spin_orb)
+  else
+    return tbt
+  end
 end
 
-function to_OBF(F :: F_OP)
-	#transforms one-body fermionic operator into one-body fragment
-	if F.Nbods != 1
-		error("Fermionic operator is not one-body, cannot transform to one-body fragment!")
-	end
+function tb_correction_2(F::F_OP; return_op=false)
+  #returns correction to one-body tensor coming from tbt inside fermionic operator F
+  if F.spin_orb
+    return F
+  else
+    if size(F.mbts[3], 1) == size(F.mbts[4], 1)
+      tbt = 3 * sum(F.mbts[4][:, :, :, :, m, m] for m in 1:F.N)
+    else
+      return F
+    end
+  end
 
-	D, U = eigen(F.mbts[2])
-	C = cartan_1b(F.spin_orb, D, F.N)
-	fU = tuple(f_matrix_rotation(F.N, U))
-
-	return F_FRAG(1, fU, OBF(), C, F.N, F.spin_orb, 1, false)
+  if return_op
+    return F_OP(([0], [0], tbt), F.spin_orb)
+  else
+    return tbt
+  end
 end
 
-function F_OP(tbt :: Array{Float64, 4}, spin_orb=false)
-	#by default assume tbt is in spacial orbitals
-	return F_OP(([0], [0], tbt), spin_orb)
+function ob_correction(tbt::Array{Float64,4}, spin_orb=false)
+  N = size(tbt)[1]
+  if spin_orb
+    return sum([tbt[:, :, r, r] for r in 1:N])
+  else
+    return 2 * sum([tbt[:, :, r, r] for r in 1:N])
+  end
 end
 
-function F_OP(obt :: Array{Float64, 2}, spin_orb=false)
-	#by default assume tbt is in spacial orbitals
-	return F_OP(([0], obt), spin_orb)
+function ob_correction(F::F_FRAG; return_op=false)
+  if return_op == false
+    return ob_correction(to_OP(F))
+  else
+    return F_OP(([0], ob_correction(to_OP(F))))
+  end
 end
 
-function to_OBF(obt :: Array{Float64, 2}, spin_orb=false)
-	return to_OBF(F_OP(obt, spin_orb))
+function initialize_FRAG(N::Int64, TECH::DF; REAL=true)
+  nUs = 1
+  if REAL
+    U = tuple(real_orbital_rotation(N, zeros(Int(N * (N - 1) / 2))))
+  else
+    U = tuple(orbital_rotation(N, zeros(Int(N^2))))
+  end
+  C = cartan_1b(false, zeros(N), N)
+
+  return F_FRAG(nUs, U, DF(), C, N, false, 1, false)
 end
 
-function F_OP_to_eri(F :: F_OP)
-	#transform fermionic operator into electronic repulsion integrals
-	obt = copy(F.mbts[2])
-	tbt = copy(F.mbts[3])
+function initialize_FRAG(N::Int64, TECH::CSA; REAL=true)
+  nUs = 1
+  if REAL
+    U = tuple(real_orbital_rotation(N, zeros(Int(N * (N - 1) / 2))))
+  else
+    U = tuple(orbital_rotation(N, zeros(Int(N^2))))
+  end
+  C = cartan_2b(false, zeros(Int(N * (N + 1) / 2)), N)
 
-	obt += sum(tbt[:,k,k,:] for k in 1:F.N)
-
-	return obt, 2*tbt
+  return F_FRAG(nUs, U, CSA(), C, N, false, 1, false)
 end
 
-function eri_to_F_OP(obt, tbt, hconst :: Array = [0]; spin_orb=false)
-	#transform electronic repulsion integrals into fermionic operator
-	N = size(obt)[1]
+function initialize_FRAG(N::Int64, TECH::THC; REAL=true)
+  nUs = 2
+  if REAL
+    U = tuple(real_orbital_rotation(N, zeros(Int(N * (N - 1) / 2))),
+      real_orbital_rotation(N, zeros(Int(N * (N - 1) / 2))))
+  else
+    U = tuple(orbital_rotation(N, zeros(Int(N^2))),
+      orbital_rotation(N, zeros(Int(N^2))))
+  end
+  C = cartan_m1()
 
-	mbts = (hconst, obt - sum([0.5*tbt[:,k,k,:] for k in 1:N]), 0.5*tbt)
-	
-	
-	return F_OP(mbts, spin_orb)
+  return F_FRAG(nUs, U, THC(), C, N, false, 1, true)
 end
 
-function eri_to_F_OP(obt, tbt, hconst :: Number)
-	return eri_to_F_OP(obt, tbt, [hconst])
+function to_OBF(F::F_OP)
+  #transforms one-body fermionic operator into one-body fragment
+  if F.Nbods != 1
+    error("Fermionic operator is not one-body, cannot transform to one-body fragment!")
+  end
+
+  D, U = eigen(F.mbts[2])
+  C = cartan_1b(F.spin_orb, D, F.N)
+  fU = tuple(f_matrix_rotation(F.N, U))
+
+  return F_FRAG(1, fU, OBF(), C, F.N, F.spin_orb, 1, false)
 end
 
-function to_CSA_SD(F :: F_FRAG)
-	#transforms fragment into CSA_SD fragment
-	if F.TECH == THC()
-		error("Cannot transform THC fragment into CSA_SD, different number of unitaries")
-	elseif F.TECH == CSA_SD()
-		return F
-	elseif F.TECH == CSA()
-		C = cartan_SD(F.spin_orb, zeros(F.N), F.C.λ, F.N)
-		return F_FRAG(F.nUs, F.U, CSA_SD(), C, F.N, F.spin_orb, F.coeff, F.has_coeff)
-	elseif F.TECH == DF()
-		Cmat = zeros(F.N, F.N)
-		for i in 1:F.N
-			for j in 1:F.N
-				Cmat[i,j] = F.C.λ[i] * F.C.λ[j]
-			end
-		end
-		C2b = cartan_mat_to_2b(Cmat, F.spin_orb)
-		C = cartan_SD(F.spin_orb, zeros(F.N), C2b.λ, F.N)
-		return F_FRAG(F.nUs, F.U, CSA_SD(), C, F.N, F.spin_orb, F.coeff, F.has_coeff)
-	else
-		error("Transformation into CSA_SD frag not defined for fragment type $(F.TECH)")
-	end
+function F_OP(tbt::Array{Float64,6}, spin_orb=false)
+  #by default assume tbt is in spacial orbitals
+  return F_OP(([0], [0], [0], tbt), spin_orb)
 end
 
+function F_OP(tbt::Array{Float64,4}, spin_orb=false)
+  #by default assume tbt is in spacial orbitals
+  return F_OP(([0], [0], tbt), spin_orb)
+end
+
+function F_OP(obt::Array{Float64,2}, spin_orb=false)
+  #by default assume tbt is in spacial orbitals
+  return F_OP(([0], obt), spin_orb)
+end
+
+function to_OBF(obt::Array{Float64,2}, spin_orb=false)
+  return to_OBF(F_OP(obt, spin_orb))
+end
+
+function F_OP_to_eri(F::F_OP)
+  #transform fermionic operator into electronic repulsion integrals
+  obt = copy(F.mbts[2])
+  tbt = copy(F.mbts[3])
+
+  obt += sum(tbt[:, k, k, :] for k in 1:F.N)
+
+  return obt, 2 * tbt
+end
+
+function eri_to_F_OP(obt, tbt, hconst::Array=[0]; spin_orb=false)
+  #Transform electronic repulsion integrals into fermionic operator
+  #Original form assumed to be:
+  # H = E_0 + h_ij a†_i a_j + 0.5*g_ijkl a†_i a†_k a_l a_j
+  #Internally stored as:
+  # H = E_0 + (h_ij-0.5*sum_k[g_ikkj]) a†_i a_j + 0.5*g_ijkl a†_i a_j a†_k a_l 
+  #   = E_0 + H_ij a†_i a_j + G_ijkl a†_i a_j a†_k a_l 
+  # where E_0 = hconst, h_ij = obt, g_ijkl = tbt,
+  # H_ij = obt - 0.5*sum_k[tbt[:,k,k,:]], G_ijkl = 0.5*tbt,
+  # and i,j,k,l refer to spatial orbitals if spin_orb = false, 
+  # and spin-orbitals if spin_orb = true
+  N = size(obt)[1]
+
+  mbts = (hconst, obt - sum([0.5 * tbt[:, k, k, :] for k in 1:N]), 0.5 * tbt)
+
+
+  return F_OP(mbts, spin_orb)
+end
+
+function eri_to_F_OP(obt, tbt, hconst::Number; spin_orb=false)
+  #Transform electronic repulsion integrals into fermionic operator
+  #Original form assumed to be:
+  # H = E_0 + h_ij a†_i a_j + 0.5*g_ijkl a†_i a†_k a_l a_j
+  #Internally stored as:
+  # H = E_0 + (h_ij-0.5*sum_k[g_ikkj]) a†_i a_j + 0.5*g_ijkl a†_i a_j a†_k a_l 
+  #   = E_0 + H_ij a†_i a_j + G_ijkl a†_i a_j a†_k a_l 
+  # where E_0 = hconst, h_ij = obt, g_ijkl = tbt,
+  # H_ij = obt - 0.5*sum_k[tbt[:,k,k,:]], G_ijkl = 0.5*tbt,
+  # and i,j,k,l refer to spatial orbitals if spin_orb = false, 
+  # and spin-orbitals if spin_orb = true
+  return eri_to_F_OP(obt, tbt, [hconst], spin_orb=spin_orb)
+end
+
+function to_CSA_SD(F::F_FRAG)
+  #transforms fragment into CSA_SD fragment
+  if F.TECH == THC()
+    error("Cannot transform THC fragment into CSA_SD, different number of unitaries")
+  elseif F.TECH == CSA_SD()
+    return F
+  elseif F.TECH == CSA()
+    C = cartan_SD(F.spin_orb, zeros(F.N), F.C.λ, F.N)
+    return F_FRAG(F.nUs, F.U, CSA_SD(), C, F.N, F.spin_orb, F.coeff, F.has_coeff)
+  elseif F.TECH == DF()
+    Cmat = zeros(F.N, F.N)
+    for i in 1:F.N
+      for j in 1:F.N
+        Cmat[i, j] = F.C.λ[i] * F.C.λ[j]
+      end
+    end
+    C2b = cartan_mat_to_2b(Cmat, F.spin_orb)
+    C = cartan_SD(F.spin_orb, zeros(F.N), C2b.λ, F.N)
+    return F_FRAG(F.nUs, F.U, CSA_SD(), C, F.N, F.spin_orb, F.coeff, F.has_coeff)
+  else
+    error("Transformation into CSA_SD frag not defined for fragment type $(F.TECH)")
+  end
+end
+
+function F_OP_converter(F::F_OP)
+  obt = zeros(2 * F.N, 2 * F.N)
+  tbt = zeros(2 * F.N, 2 * F.N, 2 * F.N, 2 * F.N)
+  for sigma in 1:2
+    for i in 1:F.N
+      for j in 1:F.N
+        obt[2*i-mod(sigma, 2), 2*j-mod(sigma, 2)] = F.mbts[2][sigma, i, j]
+      end
+    end
+  end
+  for sigma in 1:4
+    i = 0
+    j = 0
+    if sigma <= 2
+      i = 1
+    end
+    if sigma == 1 || sigma == 3
+      j = 1
+    end
+    for p in 1:F.N
+      for q in 1:F.N
+        for r in 1:F.N
+          for s in 1:F.N
+            tbt[2*p-i, 2*q-i, 2*r-j, 2*s-j] = F.mbts[3][sigma, p, q, r, s]
+          end
+        end
+      end
+    end
+  end
+  return F_OP((F.mbts[1], obt, tbt))
+end
+
+function F_OP_compress(F::F_OP)
+  N = div(F.N, 2)
+  obt = zeros(2, N, N)
+  tbt = zeros(4, N, N, N, N)
+
+  align = [1, 4]
+  anti = [2, 3]
+
+  for i in 1:F.N
+    for j in 1:F.N
+      sigma = 2 - mod(i, 2)
+      if sigma == 2 - mod(j, 2)
+        obt[sigma, ceil(Int64, i / 2), ceil(Int64, j / 2)] = F.mbts[2][i, j]
+      end
+    end
+  end
+  for p in 1:F.N
+    for q in 1:F.N
+      for r in 1:F.N
+        for s in 1:F.N
+          sigma = 2 - mod(p, 2)
+          tau = 2 - mod(r, 2)
+          if sigma == tau
+            if sigma == 2 - mod(q, 2) && tau == 2 - mod(s, 2)
+              tbt[align[sigma], ceil(Int64, p / 2), ceil(Int64, q / 2), ceil(Int64, r / 2), ceil(Int64, s / 2)] = F.mbts[3][p, q, r, s]
+            end
+          else
+            if sigma == 2 - mod(q, 2) && tau == 2 - mod(s, 2)
+              tbt[anti[sigma], ceil(Int64, p / 2), ceil(Int64, q / 2), ceil(Int64, r / 2), ceil(Int64, s / 2)] = F.mbts[3][p, q, r, s]
+            end
+          end
+        end
+      end
+    end
+  end
+
+
+  return F_OP((F.mbts[1], obt, tbt))
+end
 
 

--- a/src/UTILS/symmetries.jl
+++ b/src/UTILS/symmetries.jl
@@ -1,139 +1,178 @@
-function symmetry_builder(H :: F_OP)
-	#returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
-	Ne_obt = zeros(H.N, H.N)
-	for i in 1:H.N
-		Ne_obt[i,i] = 1
-	end
+function symmetry_builder(H::F_OP)
+  #returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
+  Ne_obt = zeros(H.N, H.N)
+  for i in 1:H.N
+    Ne_obt[i, i] = 1
+  end
 
-	Ne2_tbt = zeros(H.N, H.N, H.N, H.N)
-	for i in 1:H.N
-		for j in 1:H.N
-			Ne2_tbt[i,i,j,j] = 1
-		end
-	end
+  Ne2_tbt = zeros(H.N, H.N, H.N, H.N)
+  for i in 1:H.N
+    for j in 1:H.N
+      Ne2_tbt[i, i, j, j] = 1
+    end
+  end
+  return F_OP(([0], Ne_obt), H.spin_orb), F_OP(([0], [0], Ne2_tbt), H.spin_orb)
+end
+function symmetry_builder_extension(H::F_OP)
+  #returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
+  Ne_obt = zeros(H.N, H.N)
+  for i in 1:H.N
+    Ne_obt[i, i] = 1
+  end
 
-	return F_OP(([0],Ne_obt), H.spin_orb), F_OP(([0],[0],Ne2_tbt), H.spin_orb)
+  Ne2_tbt = zeros(H.N, H.N, H.N, H.N)
+  for i in 1:H.N
+    for j in 1:H.N
+      Ne2_tbt[i, i, j, j] = 1
+    end
+  end
+
+  Ne3_threebt = zeros(H.N, H.N, H.N, H.N, H.N, H.N)
+  for i in 1:H.N
+    for j in 1:H.N
+      for k in 1:H.N
+        Ne3_threebt[i, i, j, j, k, k] = 1
+      end
+    end
+  end
+
+  return F_OP(([0], Ne_obt), H.spin_orb), F_OP(([0], [0], Ne2_tbt), H.spin_orb), F_OP(([0], [0], [0], Ne3_threebt), H.spin_orb)
+end
+function symmetry_builder(N::Int64)
+  #returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
+  Ne_obt = zeros(N, N)
+  for i in 1:N
+    Ne_obt[i, i] = 1
+  end
+
+  Ne2_tbt = zeros(N, N, N, N)
+  for i in 1:N
+    for j in 1:N
+      Ne2_tbt[i, i, j, j] = 1
+    end
+  end
+
+  return F_OP(([0], Ne_obt)), F_OP(([0], [0], Ne2_tbt))
 end
 
-function Ne_builder(N :: Int64, spin_orb=true)
-	#returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
-	Ne_obt = zeros(N, N)
-	for i in 1:N
-		Ne_obt[i,i] = 1
-	end
+function Ne_builder(N::Int64, spin_orb=true)
+  #returns Ne and Neˆ2, both symmetries can be represented in orbitals (so no need for spin-orbitals)
+  Ne_obt = zeros(N, N)
+  for i in 1:N
+    Ne_obt[i, i] = 1
+  end
 
-	return F_OP(([0],Ne_obt), spin_orb)
+  return F_OP(([0], Ne_obt), spin_orb)
 end
 
-function Ne2_lambda_builder(N :: Int64)
-	#returns Ne^2-associated λ vector, such that cartan_2b(λ) = Ne^2
-	λ = zeros(Int(N*(N+1)/2))
+function Ne2_lambda_builder(N::Int64)
+  #returns Ne^2-associated λ vector, such that cartan_2b(λ) = Ne^2
+  λ = zeros(Int(N * (N + 1) / 2))
 
-	idx = 1
-	for i in 1:N
-		for j in 1:i
-			if i == j
-				λ[idx] = 1
-			else
-				λ[idx] = 2
-			end
-			idx += 1
-		end
-	end
+  idx = 1
+  for i in 1:N
+    for j in 1:i
+      if i == j
+        λ[idx] = 1
+      else
+        λ[idx] = 2
+      end
+      idx += 1
+    end
+  end
 
-	return λ
+  return λ
 end
 
 
-function naive_tb_symmetry_shift(H :: F_OP)
-	_,Ne2 = symmetry_builder(H)
+function naive_tb_symmetry_shift(H::F_OP)
+  _, Ne2 = symmetry_builder(H)
 
-	function cost(x)
-		return L2_partial_cost(H, x[1] * Ne2)
-	end
-	println("L2 cost before two-body symmetry shift is $(cost(0))")
+  function cost(x)
+    return L2_partial_cost(H, x[1] * Ne2)
+  end
+  println("L2 cost before two-body symmetry shift is $(cost(0))")
 
-	x0 = [0.0]
-	@time sol = optimize(cost, x0, BFGS())
-	println("Final L2 cost after two-body symmetry shift is $(sol.minimum)")
+  x0 = [0.0]
+  @time sol = optimize(cost, x0, BFGS())
+  println("Final L2 cost after two-body symmetry shift is $(sol.minimum)")
 
-	x2 = sol.minimizer[1]
+  x2 = sol.minimizer[1]
 
-	return x2, H - x2*Ne2
+  return x2, H - x2 * Ne2
 end
 
-function naive_ob_symmetry_shift(H :: F_OP; verbose=true)
-	Ne,_ = symmetry_builder(H)
+function naive_ob_symmetry_shift(H::F_OP; verbose=true)
+  Ne, _ = symmetry_builder(H)
 
-	D,_ = eigen(H.mbts[2])
-	function cost(x)
-		return sum(abs.(D - x[1]*ones(H.N)))
-	end
+  D, _ = eigen(H.mbts[2])
+  function cost(x)
+    return sum(abs.(D - x[1] * ones(H.N)))
+  end
 
-	if verbose
-		println("L1 cost before one-body symmetry shift is $(sum(abs.(D)))")
-	end
-	x0 = [0.0]
-	@time sol = optimize(cost, x0, BFGS())
-	if verbose
-		println("Final L1 cost after one-body symmetry shift is $(sol.minimum)")
-	end
+  if verbose
+    println("L1 cost before one-body symmetry shift is $(sum(abs.(D)))")
+  end
+  x0 = [0.0]
+  @time sol = optimize(cost, x0, BFGS())
+  if verbose
+    println("Final L1 cost after one-body symmetry shift is $(sol.minimum)")
+  end
 
-	x1 = sol.minimizer[1]
+  x1 = sol.minimizer[1]
 
-	return x1, H - x1*Ne
+  return x1, H - x1 * Ne
 end
 
-function symmetry_treatment(H :: F_OP; verbose=true, SAVENAME=DATAFOLDER*"SYM.h5", SAVELOAD=SAVING)
-	if verbose
-		println("Starting total L1 norm for Hamiltonian is $(PAULI_L1(H))")
-	end
-	Ne, Ne2 = symmetry_builder(H)
+function symmetry_treatment(H::F_OP; verbose=true, SAVENAME=DATAFOLDER * "SYM.h5", SAVELOAD=SAVING)
+  if verbose
+    println("Starting total L1 norm for Hamiltonian is $(PAULI_L1(H))")
+  end
+  Ne, Ne2 = symmetry_builder(H)
 
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		if haskey(fid, "SYMMETRY_SHIFT")
-			println("Found symmetry-shift saved data in $SAVENAME")
-			SS_group = fid["SYMMETRY_SHIFT"]
-			x2, x1 = read(SS_group, "shifts")
-			close(fid)
-			H2 = H - x2*Ne2
-			H_sym = H2 - x1*Ne
-			return H_sym, [x2,x1]
-		end
-		close(fid)
-	end
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    if haskey(fid, "SYMMETRY_SHIFT")
+      println("Found symmetry-shift saved data in $SAVENAME")
+      SS_group = fid["SYMMETRY_SHIFT"]
+      x2, x1 = read(SS_group, "shifts")
+      close(fid)
+      H2 = H - x2 * Ne2
+      H_sym = H2 - x1 * Ne
+      return H_sym, [x2, x1]
+    end
+    close(fid)
+  end
 
-	#x2, H2 = naive_tb_symmetry_shift(H)
-	# =
-	τ_mat = τ_mat_builder([Ne2.mbts[3]])
-	x2 = L1_linprog_optimizer_tbt(H.mbts[3], τ_mat)[1]
-	H2 = H - x2*Ne2
-	# =#
+  #x2, H2 = naive_tb_symmetry_shift(H)
+  # =
+  τ_mat = τ_mat_builder([Ne2.mbts[3]])
+  x2 = L1_linprog_optimizer_tbt(H.mbts[3], τ_mat)[1]
+  H2 = H - x2 * Ne2
+  # =#
 
-	#run one-body optimization routine over corrected one-body tensor
-	obt_corr = ob_correction(H2, return_op=true)
-	H2 += obt_corr
-	D,_ = eigen(H2.mbts[2])
-	#x1, H_sym = naive_ob_symmetry_shift(H2, verbose=verbose)
-	# =#
-	x1 = L1_linprog_one_body_Ne(H2.mbts[2])
-	H_sym = H2 - x1*Ne
+  #run one-body optimization routine over corrected one-body tensor
+  obt_corr = ob_correction(H2, return_op=true)
+  H2 += obt_corr
+  D, _ = eigen(H2.mbts[2])
+  #x1, H_sym = naive_ob_symmetry_shift(H2, verbose=verbose)
+  # =#
+  x1 = L1_linprog_one_body_Ne(H2.mbts[2])
+  H_sym = H2 - x1 * Ne
 
-	# =#
+  # =#
 
-	if verbose
-		println("Final total L1 norm for symmetry-shifted Hamiltonian is $(PAULI_L1(H_sym))")
-	end
+  if verbose
+    println("Final total L1 norm for symmetry-shifted Hamiltonian is $(PAULI_L1(H_sym))")
+  end
 
-	if SAVELOAD
-		fid = h5open(SAVENAME, "cw")
-		create_group(fid, "SYMMETRY_SHIFT")
-		SS_group = fid["SYMMETRY_SHIFT"]
-		SS_group["shifts"] = [x2, x1]
-		close(fid)
-	end
+  if SAVELOAD
+    fid = h5open(SAVENAME, "cw")
+    create_group(fid, "SYMMETRY_SHIFT")
+    SS_group = fid["SYMMETRY_SHIFT"]
+    SS_group["shifts"] = [x2, x1]
+    close(fid)
+  end
 
-	return H_sym - obt_corr, [x2, x1]
+  return H_sym - obt_corr, [x2, x1]
 end
-


### PR DESCRIPTION
Extending the BLISS operation to reduce the 1-Norm of the Hamiltonian up-to-three body terms using the Linear Programming.

The details of the derivations of the 1-Norms and the cost functions are defined in a private Overleaf document.
The new code contains
* `bliss_linprog_extension` function that extends `bliss_linprog`
This function currently only takes spatial orbital coefficient tensors of a Hamiltonian
* `bliss_test` function that checks the ground-state energy in the same subspace being conserved as well as the spectral range gets smaller or equal to that of the original Hamiltonian after BLISS. 